### PR TITLE
Add NULL checks

### DIFF
--- a/src/SDL_shadercross.c
+++ b/src/SDL_shadercross.c
@@ -685,7 +685,7 @@ static ID3DBlob *SDL_ShaderCross_INTERNAL_CompileDXBC(
         &errorBlob);
 
     if (ret < 0) {
-        if(errorBlob != NULL) {
+        if (errorBlob != NULL) {
             SDL_SetError(
                 "HLSL compilation failed: %s",
                 (char *)errorBlob->lpVtbl->GetBufferPointer(errorBlob));
@@ -1738,7 +1738,9 @@ static void *SDL_ShaderCross_INTERNAL_CompileFromSPIRV(
         bytecodeSize,
         entrypoint);
 
-    if(transpileContext == NULL) return NULL;
+    if (transpileContext == NULL) {
+        return NULL;
+    }
 
     void *shaderObject = NULL;
 
@@ -1826,7 +1828,9 @@ void *SDL_ShaderCross_TranspileMSLFromSPIRV(
         entrypoint
     );
 
-    if(context == NULL) return NULL;
+    if (context == NULL) {
+        return NULL;
+    }
 
     size_t length = SDL_strlen(context->translated_source) + 1;
     char *result = SDL_malloc(length);
@@ -1851,7 +1855,9 @@ void *SDL_ShaderCross_TranspileHLSLFromSPIRV(
         entrypoint
     );
 
-    if(context == NULL) return NULL;
+    if (context == NULL) {
+        return NULL;
+    }
 
     size_t length = SDL_strlen(context->translated_source) + 1;
     char *result = SDL_malloc(length);
@@ -1876,7 +1882,9 @@ void *SDL_ShaderCross_CompileDXBCFromSPIRV(
         bytecodeSize,
         entrypoint);
 
-    if(context == NULL) return NULL;
+    if (context == NULL) {
+        return NULL;
+    }
 
     void *result = SDL_ShaderCross_INTERNAL_CompileDXBCFromHLSL(
         context->translated_source,
@@ -1910,7 +1918,9 @@ void *SDL_ShaderCross_CompileDXILFromSPIRV(
         bytecodeSize,
         entrypoint);
 
-    if(context == NULL) return NULL;
+    if (context == NULL) {
+        return NULL;
+    }
 
     void *result = SDL_ShaderCross_CompileDXILFromHLSL(
         context->translated_source,

--- a/src/SDL_shadercross.c
+++ b/src/SDL_shadercross.c
@@ -685,9 +685,13 @@ static ID3DBlob *SDL_ShaderCross_INTERNAL_CompileDXBC(
         &errorBlob);
 
     if (ret < 0) {
-        SDL_SetError(
-            "HLSL compilation failed: %s",
-            (char *)errorBlob->lpVtbl->GetBufferPointer(errorBlob));
+        if(errorBlob != NULL) {
+            SDL_SetError(
+                "HLSL compilation failed: %s",
+                (char *)errorBlob->lpVtbl->GetBufferPointer(errorBlob));
+        } else {
+            SDL_SetError("HLSL compilation failed for an unknown reason.");
+        }
         return NULL;
     }
 

--- a/src/SDL_shadercross.c
+++ b/src/SDL_shadercross.c
@@ -1734,6 +1734,8 @@ static void *SDL_ShaderCross_INTERNAL_CompileFromSPIRV(
         bytecodeSize,
         entrypoint);
 
+    if(transpileContext == NULL) return NULL;
+
     void *shaderObject = NULL;
 
     if (shaderStage == SDL_SHADERCROSS_SHADERSTAGE_COMPUTE) {
@@ -1820,6 +1822,8 @@ void *SDL_ShaderCross_TranspileMSLFromSPIRV(
         entrypoint
     );
 
+    if(context == NULL) return NULL;
+
     size_t length = SDL_strlen(context->translated_source) + 1;
     char *result = SDL_malloc(length);
     SDL_strlcpy(result, context->translated_source, length);
@@ -1843,6 +1847,8 @@ void *SDL_ShaderCross_TranspileHLSLFromSPIRV(
         entrypoint
     );
 
+    if(context == NULL) return NULL;
+
     size_t length = SDL_strlen(context->translated_source) + 1;
     char *result = SDL_malloc(length);
     SDL_strlcpy(result, context->translated_source, length);
@@ -1865,6 +1871,8 @@ void *SDL_ShaderCross_CompileDXBCFromSPIRV(
         bytecode,
         bytecodeSize,
         entrypoint);
+
+    if(context == NULL) return NULL;
 
     void *result = SDL_ShaderCross_INTERNAL_CompileDXBCFromHLSL(
         context->translated_source,
@@ -1897,6 +1905,8 @@ void *SDL_ShaderCross_CompileDXILFromSPIRV(
         bytecode,
         bytecodeSize,
         entrypoint);
+
+    if(context == NULL) return NULL;
 
     void *result = SDL_ShaderCross_CompileDXILFromHLSL(
         context->translated_source,


### PR DESCRIPTION
This function can return NULL on error, and right now a null de-reference occurs when this happened.

All cases where it returns NULL, it also sets the SDL error string, so I don't do that here.

Also fixed a similar case when calling D3DCompile. vkd3d logs to the console on its own, but does not set the error blob.
`vkd3d:60115:fixme:hlsl_compile_shader Unknown compilation target "vs_5_1".`