### PR TITLE
Added --debuginfo argument to create debugging information

### DIFF
--- a/include/SDL3_shadercross/SDL_shadercross.h
+++ b/include/SDL3_shadercross/SDL_shadercross.h
@@ -137,7 +137,8 @@ extern SDL_DECLSPEC void * SDLCALL SDL_ShaderCross_CompileDXBCFromSPIRV(
     size_t bytecodeSize,
     const char *entrypoint,
     SDL_ShaderCross_ShaderStage shaderStage,
-    size_t *size);
+    size_t *size,
+    bool debugInfoEnabled);
 
 /**
  * Compile DXIL bytecode from SPIRV code.
@@ -155,7 +156,8 @@ extern SDL_DECLSPEC void * SDLCALL SDL_ShaderCross_CompileDXILFromSPIRV(
     size_t bytecodeSize,
     const char *entrypoint,
     SDL_ShaderCross_ShaderStage shaderStage,
-    size_t *size);
+    size_t *size,
+    bool debugInfoEnabled);
 
 /**
  * Compile an SDL GPU shader from SPIRV code.
@@ -255,7 +257,8 @@ extern SDL_DECLSPEC void * SDLCALL SDL_ShaderCross_CompileDXBCFromHLSL(
     char **defines,
     Uint32 numDefines,
     SDL_ShaderCross_ShaderStage shaderStage,
-    size_t *size);
+    size_t *size,
+    bool debugInfoEnabled);
 
 /**
  * Compile to DXIL bytecode from HLSL code via a SPIRV-Cross round trip.
@@ -280,7 +283,8 @@ extern SDL_DECLSPEC void * SDLCALL SDL_ShaderCross_CompileDXILFromHLSL(
     char **defines,
     Uint32 numDefines,
     SDL_ShaderCross_ShaderStage shaderStage,
-    size_t *size);
+    size_t *size,
+    bool debugInfoEnabled);
 
 /**
  * Compile to SPIRV bytecode from HLSL code.
@@ -305,7 +309,8 @@ extern SDL_DECLSPEC void * SDLCALL SDL_ShaderCross_CompileSPIRVFromHLSL(
     char **defines,
     Uint32 numDefines,
     SDL_ShaderCross_ShaderStage shaderStage,
-    size_t *size);
+    size_t *size,
+    bool debugInfoEnabled);
 
 /**
  * Compile an SDL GPU shader from HLSL code.
@@ -330,7 +335,8 @@ extern SDL_DECLSPEC SDL_GPUShader * SDLCALL SDL_ShaderCross_CompileGraphicsShade
     char **defines,
     Uint32 numDefines,
     SDL_GPUShaderStage graphicsShaderStage,
-    SDL_ShaderCross_GraphicsShaderInfo *info);
+    SDL_ShaderCross_GraphicsShaderInfo *info,
+    bool debugInfoEnabled);
 
 /**
  * Compile an SDL GPU compute pipeline from code.
@@ -353,7 +359,8 @@ extern SDL_DECLSPEC SDL_GPUComputePipeline * SDLCALL SDL_ShaderCross_CompileComp
     const char *includeDir,
     char **defines,
     Uint32 numDefines,
-    SDL_ShaderCross_ComputePipelineInfo *info);
+    SDL_ShaderCross_ComputePipelineInfo *info,
+    bool debugInfoEnabled);
 
 #ifdef __cplusplus
 }

--- a/src/cli.c
+++ b/src/cli.c
@@ -47,6 +47,7 @@ void print_help(void)
     SDL_Log("Optional options:\n");
     SDL_Log("  %-*s %s", column_width, "-I | --include <value>", "HLSL include directory. Only used with HLSL source.");
     SDL_Log("  %-*s %s", column_width, "-D<value>", "HLSL define. Only used with HLSL source. Can be repeated.");
+    SDL_Log("  %-*s %s", column_width, "--debuginfo", "Generate HLSL debugging information. Only used with HLSL source.");
 }
 
 void write_graphics_reflect_json(SDL_IOStream *outputIO, SDL_ShaderCross_GraphicsShaderInfo *info)
@@ -98,6 +99,8 @@ int main(int argc, char *argv[])
 
     Uint32 numDefines = 0;
     char **defines = NULL;
+
+    bool debugInfo = false;
 
     for (int i = 1; i < argc; i += 1) {
         char *arg = argv[i];
@@ -208,6 +211,8 @@ int main(int argc, char *argv[])
                 numDefines += 1;
                 defines = SDL_realloc(defines, sizeof(char *) * numDefines);
                 defines[numDefines - 1] = argv[i];
+            } else if (strncmp(argv[i], "--debuginfo", strlen("--debuginfo")) == 0) {
+                debugInfo = true;
             } else if (SDL_strcmp(arg, "--") == 0) {
                 accept_optionals = false;
             } else {
@@ -309,7 +314,8 @@ int main(int argc, char *argv[])
                     fileSize,
                     entrypointName,
                     shaderStage,
-                    &bytecodeSize);
+                    &bytecodeSize,
+                    debugInfo);
                 if (buffer == NULL) {
                     SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Failed to compile DXBC from SPIR-V: %s", SDL_GetError());
                     result = 1;
@@ -326,7 +332,8 @@ int main(int argc, char *argv[])
                     fileSize,
                     entrypointName,
                     shaderStage,
-                    &bytecodeSize);
+                    &bytecodeSize,
+                    debugInfo);
                 if (buffer == NULL) {
                     SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Failed to compile DXIL from SPIR-V: %s", SDL_GetError());
                     result = 1;
@@ -418,7 +425,8 @@ int main(int argc, char *argv[])
                     defines,
                     numDefines,
                     shaderStage,
-                    &bytecodeSize);
+                    &bytecodeSize,
+                    debugInfo);
                 if (buffer == NULL) {
                     SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Failed to compile DXBC from HLSL: %s", SDL_GetError());
                     result = 1;
@@ -437,7 +445,8 @@ int main(int argc, char *argv[])
                     defines,
                     numDefines,
                     shaderStage,
-                    &bytecodeSize);
+                    &bytecodeSize,
+                    debugInfo);
                 if (buffer == NULL) {
                     SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Failed to compile DXIL from HLSL: %s", SDL_GetError());
                     result = 1;
@@ -457,7 +466,8 @@ int main(int argc, char *argv[])
                     defines,
                     numDefines,
                     shaderStage,
-                    &bytecodeSize);
+                    &bytecodeSize,
+                    debugInfo);
                 if (spirv == NULL) {
                     SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Failed to transpile MSL from HLSL: %s", SDL_GetError());
                     result = 1;
@@ -487,7 +497,8 @@ int main(int argc, char *argv[])
                     defines,
                     numDefines,
                     shaderStage,
-                    &bytecodeSize);
+                    &bytecodeSize,
+                    debugInfo);
                 if (buffer == NULL) {
                     SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Failed to compile SPIR-V From HLSL: %s", SDL_GetError());
                     result = 1;
@@ -506,7 +517,8 @@ int main(int argc, char *argv[])
                     defines,
                     numDefines,
                     shaderStage,
-                    &bytecodeSize);
+                    &bytecodeSize,
+                    debugInfo);
 
                 if (spirv == NULL) {
                     SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Failed to compile HLSL to SPIRV: %s", SDL_GetError());
@@ -540,7 +552,8 @@ int main(int argc, char *argv[])
                     defines,
                     numDefines,
                     shaderStage,
-                    &bytecodeSize);
+                    &bytecodeSize,
+                    debugInfo);
 
                 if (spirv == NULL) {
                     SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Failed to compile HLSL to SPIRV: %s", SDL_GetError());


### PR DESCRIPTION
Adds a new `--debuginfo`  argument to the CLI and `bool debugInfoEnabled` parameter to the relevant API to allow the compilation of shader with debugging information embedded in them.

Tested using RenderDoc with:

- [x] **SPIR-V:** [Seems to work fine](https://github.com/user-attachments/assets/a5bf7b87-041b-4436-940d-38c565d364d8)
- [ ] **DXIL:** RenderDoc [doesn't seem to support DXIL debugging](https://renderdoc.org/docs/behind_scenes/d3d12_support.html). Is there any other way to test this?
- [ ] **MSL:** No Apple hardware available to test.

Closes https://github.com/libsdl-org/SDL_shadercross/issues/64