### PR TITLE
Allow library users to print DXC errors.

### DIFF
--- a/src/SDL_shadercross.c
+++ b/src/SDL_shadercross.c
@@ -835,7 +835,7 @@ static void *SDL_ShaderCross_INTERNAL_CreateShaderFromHLSL(
         &bytecodeSize);
 
     if (spirv == NULL) {
-        SDL_SetError("%s", "Failed to compile SPIR-V!");
+        // Error output from DXC will have already been set
         return NULL;
     }
 


### PR DESCRIPTION
As mentioned in #67 removing this line allows me to print the dxc compiler output.