### PR TITLE
Refactor parameters to info structs and add debug support

### DIFF
--- a/include/SDL3_shadercross/SDL_shadercross.h
+++ b/include/SDL3_shadercross/SDL_shadercross.h
@@ -78,13 +78,18 @@ typedef struct SDL_ShaderCross_SPIRV_Info
     SDL_PropertiesID props;                    /**< A properties ID for extensions. Should be 0 if no extensions are needed. */
 } SDL_ShaderCross_SPIRV_Info;
 
+typedef struct SDL_ShaderCross_HLSL_Define
+{
+    char *name;   /**< The define name. */
+    char *value;  /**< An optional value for the define. Can be NULL. */
+} SDL_ShaderCross_HLSL_Define;
+
 typedef struct SDL_ShaderCross_HLSL_Info
 {
     const char *source;                        /**< The HLSL source code for the shader. */
     const char *entrypoint;                    /**< The entry point function name for the shader in UTF-8. */
     const char *include_dir;                   /**< The include directory for shader code. Optional, can be NULL. */
-    char **defines;                            /**< An array of define strings. Optional, can be NULL. */
-    Uint32 num_defines;                        /**< The number of strings in the defines array. */
+    SDL_ShaderCross_HLSL_Define *defines;      /**< An array of defines. Optional, can be NULL. If not NULL, must be terminated with a fully NULL define struct. */
     SDL_ShaderCross_ShaderStage shader_stage;  /**< The shader stage to compile the shader with. */
     bool enable_debug;                         /**< Allows debug info to be emitted when relevant. Can be useful for graphics debuggers like RenderDoc. */
     const char *name;                          /**< A UTF-8 name to associate with the shader. Optional, can be NULL. */

--- a/include/SDL3_shadercross/SDL_shadercross.h
+++ b/include/SDL3_shadercross/SDL_shadercross.h
@@ -47,49 +47,49 @@ typedef enum SDL_ShaderCross_ShaderStage
 
 typedef struct SDL_ShaderCross_GraphicsShaderMetadata
 {
-    Uint32 numSamplers;         /**< The number of samplers defined in the shader. */
-    Uint32 numStorageTextures;  /**< The number of storage textures defined in the shader. */
-    Uint32 numStorageBuffers;   /**< The number of storage buffers defined in the shader. */
-    Uint32 numUniformBuffers;   /**< The number of uniform buffers defined in the shader. */
+    Uint32 num_samplers;          /**< The number of samplers defined in the shader. */
+    Uint32 num_storage_textures;  /**< The number of storage textures defined in the shader. */
+    Uint32 num_storage_buffers;   /**< The number of storage buffers defined in the shader. */
+    Uint32 num_uniform_buffers;   /**< The number of uniform buffers defined in the shader. */
 } SDL_ShaderCross_GraphicsShaderMetadata;
 
 typedef struct SDL_ShaderCross_ComputePipelineMetadata
 {
-    Uint32 numSamplers;                  /**< The number of samplers defined in the shader. */
-    Uint32 numReadOnlyStorageTextures;   /**< The number of readonly storage textures defined in the shader. */
-    Uint32 numReadOnlyStorageBuffers;    /**< The number of readonly storage buffers defined in the shader. */
-    Uint32 numReadWriteStorageTextures;  /**< The number of read-write storage textures defined in the shader. */
-    Uint32 numReadWriteStorageBuffers;   /**< The number of read-write storage buffers defined in the shader. */
-    Uint32 numUniformBuffers;            /**< The number of uniform buffers defined in the shader. */
-    Uint32 threadCountX;                 /**< The number of threads in the X dimension. */
-    Uint32 threadCountY;                 /**< The number of threads in the Y dimension. */
-    Uint32 threadCountZ;                 /**< The number of threads in the Z dimension. */
+    Uint32 num_samplers;                    /**< The number of samplers defined in the shader. */
+    Uint32 num_readonly_storage_textures;   /**< The number of readonly storage textures defined in the shader. */
+    Uint32 num_readonly_storage_buffers;    /**< The number of readonly storage buffers defined in the shader. */
+    Uint32 num_readwrite_storage_textures;  /**< The number of read-write storage textures defined in the shader. */
+    Uint32 num_readwrite_storage_buffers;   /**< The number of read-write storage buffers defined in the shader. */
+    Uint32 num_uniform_buffers;             /**< The number of uniform buffers defined in the shader. */
+    Uint32 threadcount_x;                   /**< The number of threads in the X dimension. */
+    Uint32 threadcount_y;                   /**< The number of threads in the Y dimension. */
+    Uint32 threadcount_z;                   /**< The number of threads in the Z dimension. */
 } SDL_ShaderCross_ComputePipelineMetadata;
 
 typedef struct SDL_ShaderCross_SPIRV_Info
 {
-    const Uint8 *bytecode;                    /**< The SPIRV bytecode. */
-    size_t bytecodeSize;                      /**< The length of the SPIRV bytecode. */
-    const char *entrypoint;                   /**< The entry point function name for the shader in UTF-8. */
-    SDL_ShaderCross_ShaderStage shaderStage;  /**< The shader stage to transpile the shader with. */
-    bool enableDebug;                         /**< Allows debug info to be emitted when relevant. Can be useful for graphics debuggers like RenderDoc. */
-    const char *name;                         /**< A UTF-8 name to associate with the shader. Optional, can be NULL. */
+    const Uint8 *bytecode;                     /**< The SPIRV bytecode. */
+    size_t bytecode_size;                      /**< The length of the SPIRV bytecode. */
+    const char *entrypoint;                    /**< The entry point function name for the shader in UTF-8. */
+    SDL_ShaderCross_ShaderStage shader_stage;  /**< The shader stage to transpile the shader with. */
+    bool enable_debug;                         /**< Allows debug info to be emitted when relevant. Can be useful for graphics debuggers like RenderDoc. */
+    const char *name;                          /**< A UTF-8 name to associate with the shader. Optional, can be NULL. */
 
-    SDL_PropertiesID props;                   /**< A properties ID for extensions. Should be 0 if no extensions are needed. */
+    SDL_PropertiesID props;                    /**< A properties ID for extensions. Should be 0 if no extensions are needed. */
 } SDL_ShaderCross_SPIRV_Info;
 
 typedef struct SDL_ShaderCross_HLSL_Info
 {
-    const char *hlslSource;                   /**< The HLSL source code for the shader. */
-    const char *entrypoint;                   /**< The entry point function name for the shader in UTF-8. */
-    const char *includeDir;                   /**< The include directory for shader code. Optional, can be NULL. */
-    char **defines;                           /**< An array of define strings. Optional, can be NULL. */
-    Uint32 numDefines;                        /**< The number of strings in the defines array. */
-    SDL_ShaderCross_ShaderStage shaderStage;  /**< The shader stage to compile the shader with. */
-    bool enableDebug;                         /**< Allows debug info to be emitted when relevant. Can be useful for graphics debuggers like RenderDoc. */
-    const char *name;                         /**< A UTF-8 name to associate with the shader. Optional, can be NULL. */
+    const char *source;                        /**< The HLSL source code for the shader. */
+    const char *entrypoint;                    /**< The entry point function name for the shader in UTF-8. */
+    const char *include_dir;                   /**< The include directory for shader code. Optional, can be NULL. */
+    char **defines;                            /**< An array of define strings. Optional, can be NULL. */
+    Uint32 num_defines;                        /**< The number of strings in the defines array. */
+    SDL_ShaderCross_ShaderStage shader_stage;  /**< The shader stage to compile the shader with. */
+    bool enable_debug;                         /**< Allows debug info to be emitted when relevant. Can be useful for graphics debuggers like RenderDoc. */
+    const char *name;                          /**< A UTF-8 name to associate with the shader. Optional, can be NULL. */
 
-    SDL_PropertiesID props;                   /**< A properties ID for extensions. Should be 0 if no extensions are needed. */
+    SDL_PropertiesID props;                    /**< A properties ID for extensions. Should be 0 if no extensions are needed. */
 } SDL_ShaderCross_HLSL_Info;
 
 /**
@@ -194,28 +194,28 @@ extern SDL_DECLSPEC SDL_GPUComputePipeline * SDLCALL SDL_ShaderCross_CompileComp
  * Reflect graphics shader info from SPIRV code.
  *
  * \param bytecode the SPIRV bytecode.
- * \param bytecodeSize the length of the SPIRV bytecode.
+ * \param bytecode_size the length of the SPIRV bytecode.
  * \param metadata a pointer filled in with shader metadata.
  *
  * \threadsafety It is safe to call this function from any thread.
  */
 extern SDL_DECLSPEC bool SDLCALL SDL_ShaderCross_ReflectGraphicsSPIRV(
     const Uint8 *bytecode,
-    size_t bytecodeSize,
+    size_t bytecode_size,
     SDL_ShaderCross_GraphicsShaderMetadata *metadata);
 
 /**
  * Reflect compute pipeline info from SPIRV code.
  *
  * \param bytecode the SPIRV bytecode.
- * \param bytecodeSize the length of the SPIRV bytecode.
+ * \param bytecode_size the length of the SPIRV bytecode.
  * \param metadata a pointer filled in with compute pipeline metadata.
  *
  * \threadsafety It is safe to call this function from any thread.
  */
 extern SDL_DECLSPEC bool SDLCALL SDL_ShaderCross_ReflectComputeSPIRV(
     const Uint8 *bytecode,
-    size_t bytecodeSize,
+    size_t bytecode_size,
     SDL_ShaderCross_ComputePipelineMetadata *metadata);
 
 /**

--- a/include/SDL3_shadercross/SDL_shadercross.h
+++ b/include/SDL3_shadercross/SDL_shadercross.h
@@ -73,6 +73,7 @@ typedef struct SDL_ShaderCross_SPIRV_Info
     const char *entrypoint;                   /**< The entry point function name for the shader in UTF-8. */
     SDL_ShaderCross_ShaderStage shaderStage;  /**< The shader stage to transpile the shader with. */
     bool enableDebug;                         /**< Allows debug info to be emitted when relevant. Can be useful for graphics debuggers like RenderDoc. */
+    const char *name;                         /**< A UTF-8 name to associate with the shader. Optional, can be NULL. */
 
     SDL_PropertiesID props;                   /**< A properties ID for extensions. Should be 0 if no extensions are needed. */
 } SDL_ShaderCross_SPIRV_Info;
@@ -86,6 +87,7 @@ typedef struct SDL_ShaderCross_HLSL_Info
     Uint32 numDefines;                        /**< The number of strings in the defines array. */
     SDL_ShaderCross_ShaderStage shaderStage;  /**< The shader stage to compile the shader with. */
     bool enableDebug;                         /**< Allows debug info to be emitted when relevant. Can be useful for graphics debuggers like RenderDoc. */
+    const char *name;                         /**< A UTF-8 name to associate with the shader. Optional, can be NULL. */
 
     SDL_PropertiesID props;                   /**< A properties ID for extensions. Should be 0 if no extensions are needed. */
 } SDL_ShaderCross_HLSL_Info;

--- a/src/SDL_shadercross.c
+++ b/src/SDL_shadercross.c
@@ -457,7 +457,7 @@ static void *SDL_ShaderCross_INTERNAL_CompileUsingDXC(
     if (info->enableDebug) {
         if (spirv) {
             // https://github.com/microsoft/DirectXShaderCompiler/blob/main/docs/SPIR-V.rst#debugging
-            args[argCount++] = (LPCWSTR)L"-fpsv-debug=vulkan-with-source";
+            args[argCount++] = (LPCWSTR)L"-fspv-debug=vulkan-with-source";
         } else {
             // https://github.com/microsoft/DirectXShaderCompiler/blob/main/docs/SourceLevelDebuggingHLSL.rst#command-line-options
             args[argCount++] = (LPCWSTR)L"-Zi";
@@ -668,10 +668,12 @@ typedef HRESULT(__stdcall *pfn_D3DCompile)(
 
 static pfn_D3DCompile SDL_D3DCompile = NULL;
 
+// FIXME: includes and defines
 static ID3DBlob *SDL_ShaderCross_INTERNAL_CompileDXBC(
     const char *hlslSource,
     const char *entrypoint,
-    const char *shaderProfile)
+    const char *shaderProfile,
+    bool enableDebug)
 {
     ID3DBlob *blob;
     ID3DBlob *errorBlob;
@@ -690,7 +692,7 @@ static ID3DBlob *SDL_ShaderCross_INTERNAL_CompileDXBC(
         NULL,
         entrypoint,
         shaderProfile,
-        0,
+        enableDebug ? 1 : 0, // D3DCOMPILE_DEBUG = 1
         0,
         &blob,
         &errorBlob);
@@ -756,7 +758,8 @@ void *SDL_ShaderCross_INTERNAL_CompileDXBCFromHLSL(
     ID3DBlob *blob = SDL_ShaderCross_INTERNAL_CompileDXBC(
         transpiledSource != NULL ? transpiledSource : info->hlslSource,
         info->entrypoint,
-        shaderProfile);
+        shaderProfile,
+        info->enableDebug);
 
     if (blob == NULL) {
         *size = 0;

--- a/src/SDL_shadercross.c
+++ b/src/SDL_shadercross.c
@@ -403,10 +403,10 @@ static void *SDL_ShaderCross_INTERNAL_CompileUsingDXC(
         return NULL;
     }
 
-    LPCWSTR *args = SDL_malloc(sizeof(LPCWSTR) * (info->numDefines + 10));
+    LPCWSTR *args = SDL_malloc(sizeof(LPCWSTR) * (info->num_defines + 10));
     Uint32 argCount = 0;
 
-    for (Uint32 i = 0; i < info->numDefines; i += 1) {
+    for (Uint32 i = 0; i < info->num_defines; i += 1) {
         args[argCount++] = (wchar_t *)SDL_iconv_string("WCHAR_T", "UTF-8", info->defines[i], SDL_utf8strlen(info->defines[i]) + 1);
         if (args[argCount - 1] == NULL) {
             SDL_SetError("%s", "Failed to convert define argument to WCHAR_T!");
@@ -420,9 +420,9 @@ static void *SDL_ShaderCross_INTERNAL_CompileUsingDXC(
     args[argCount++] = (LPCWSTR)L"-E";
     args[argCount++] = (LPCWSTR)entryPointUtf16;
 
-    if (info->includeDir != NULL) {
-        includeDirLength = SDL_utf8strlen(info->includeDir) + 1;
-        includeDirUtf16 = (wchar_t *)SDL_iconv_string("WCHAR_T", "UTF-8", info->includeDir, includeDirLength);
+    if (info->include_dir != NULL) {
+        includeDirLength = SDL_utf8strlen(info->include_dir) + 1;
+        includeDirUtf16 = (wchar_t *)SDL_iconv_string("WCHAR_T", "UTF-8", info->include_dir, includeDirLength);
 
         if (includeDirUtf16 == NULL) {
             SDL_SetError("%s", "Failed to convert include dir to WCHAR_T!");
@@ -436,14 +436,14 @@ static void *SDL_ShaderCross_INTERNAL_CompileUsingDXC(
         argCount += 2;
     }
 
-    source.Ptr = info->hlslSource;
-    source.Size = SDL_strlen(info->hlslSource) + 1;
+    source.Ptr = info->source;
+    source.Size = SDL_strlen(info->source) + 1;
     source.Encoding = DXC_CP_ACP;
 
-    if (info->shaderStage == SDL_SHADERCROSS_SHADERSTAGE_VERTEX) {
+    if (info->shader_stage == SDL_SHADERCROSS_SHADERSTAGE_VERTEX) {
         args[argCount++] = (LPCWSTR)L"-T";
         args[argCount++] = (LPCWSTR)L"vs_6_0";
-    } else if (info->shaderStage == SDL_SHADERCROSS_SHADERSTAGE_FRAGMENT) {
+    } else if (info->shader_stage == SDL_SHADERCROSS_SHADERSTAGE_FRAGMENT) {
         args[argCount++] = (LPCWSTR)L"-T";
         args[argCount++] = (LPCWSTR)L"ps_6_0";
     } else { // compute
@@ -455,7 +455,7 @@ static void *SDL_ShaderCross_INTERNAL_CompileUsingDXC(
         args[argCount++] = (LPCWSTR)L"-spirv";
     }
 
-    if (info->enableDebug) {
+    if (info->enable_debug) {
         if (spirv) {
             // https://github.com/microsoft/DirectXShaderCompiler/blob/main/docs/SPIR-V.rst#debugging
             args[argCount++] = (LPCWSTR)L"-fspv-debug=vulkan-with-source";
@@ -544,7 +544,7 @@ static void *SDL_ShaderCross_INTERNAL_CompileUsingDXC(
     dxcInstance->lpVtbl->Release(dxcInstance);
     utils->lpVtbl->Release(utils);
 
-    for (Uint32 i = 0; i < info->numDefines; i += 1) {
+    for (Uint32 i = 0; i < info->num_defines; i += 1) {
         SDL_free(args[i]);
     }
     SDL_free(args);
@@ -572,10 +572,10 @@ void *SDL_ShaderCross_CompileDXILFromHLSL(
 
     SDL_ShaderCross_SPIRV_Info spirvInfo;
     spirvInfo.bytecode = spirv;
-    spirvInfo.bytecodeSize = spirvSize;
+    spirvInfo.bytecode_size = spirvSize;
     spirvInfo.entrypoint = info->entrypoint;
-    spirvInfo.shaderStage = info->shaderStage;
-    spirvInfo.enableDebug = info->enableDebug;
+    spirvInfo.shader_stage = info->shader_stage;
+    spirvInfo.enable_debug = info->enable_debug;
     spirvInfo.name = info->name;
     spirvInfo.props = 0;
 
@@ -589,7 +589,7 @@ void *SDL_ShaderCross_CompileDXILFromHLSL(
 
     SDL_ShaderCross_HLSL_Info translatedHlslInfo;
     SDL_memcpy(&translatedHlslInfo, info, sizeof(SDL_ShaderCross_HLSL_Info));
-    translatedHlslInfo.hlslSource = translatedSource;
+    translatedHlslInfo.source = translatedSource;
 
     return SDL_ShaderCross_INTERNAL_CompileUsingDXC(
         &translatedHlslInfo,
@@ -743,10 +743,10 @@ void *SDL_ShaderCross_INTERNAL_CompileDXBCFromHLSL(
 
         SDL_ShaderCross_SPIRV_Info spirvInfo;
         spirvInfo.bytecode = spirv;
-        spirvInfo.bytecodeSize = spirv_size;
+        spirvInfo.bytecode_size = spirv_size;
         spirvInfo.entrypoint = info->entrypoint;
-        spirvInfo.shaderStage = info->shaderStage;
-        spirvInfo.enableDebug = info->enableDebug;
+        spirvInfo.shader_stage = info->shader_stage;
+        spirvInfo.enable_debug = info->enable_debug;
         spirvInfo.name = info->name;
         spirvInfo.props = 0;
 
@@ -760,19 +760,19 @@ void *SDL_ShaderCross_INTERNAL_CompileDXBCFromHLSL(
     }
 
     const char *shaderProfile;
-    if (info->shaderStage == SDL_SHADERCROSS_SHADERSTAGE_VERTEX) {
+    if (info->shader_stage == SDL_SHADERCROSS_SHADERSTAGE_VERTEX) {
         shaderProfile = "vs_5_1";
-    } else if (info->shaderStage == SDL_SHADERCROSS_SHADERSTAGE_FRAGMENT) {
+    } else if (info->shader_stage == SDL_SHADERCROSS_SHADERSTAGE_FRAGMENT) {
         shaderProfile = "ps_5_1";
     } else { // compute
         shaderProfile = "cs_5_1";
     }
 
     ID3DBlob *blob = SDL_ShaderCross_INTERNAL_CompileDXBC(
-        transpiledSource != NULL ? transpiledSource : info->hlslSource,
+        transpiledSource != NULL ? transpiledSource : info->source,
         info->entrypoint,
         shaderProfile,
-        info->enableDebug);
+        info->enable_debug);
 
     if (blob == NULL) {
         *size = 0;
@@ -821,15 +821,15 @@ static void *SDL_ShaderCross_INTERNAL_CreateShaderFromHLSL(
 
     SDL_ShaderCross_SPIRV_Info spirvInfo;
     spirvInfo.bytecode = spirv;
-    spirvInfo.bytecodeSize = bytecodeSize;
+    spirvInfo.bytecode_size = bytecodeSize;
     spirvInfo.entrypoint = info->entrypoint;
-    spirvInfo.shaderStage = info->shaderStage;
-    spirvInfo.enableDebug = info->enableDebug;
+    spirvInfo.shader_stage = info->shader_stage;
+    spirvInfo.enable_debug = info->enable_debug;
     spirvInfo.name = info->name;
     spirvInfo.props = 0;
 
     void *result;
-    if (info->shaderStage == SDL_SHADERCROSS_SHADERSTAGE_COMPUTE) {
+    if (info->shader_stage == SDL_SHADERCROSS_SHADERSTAGE_COMPUTE) {
         result = SDL_ShaderCross_CompileComputePipelineFromSPIRV(
             device,
             &spirvInfo,
@@ -1704,10 +1704,10 @@ bool SDL_ShaderCross_ReflectGraphicsSPIRV(
 
     spvc_context_destroy(context);
 
-    metadata->numSamplers = num_texture_samplers;
-    metadata->numStorageTextures = num_storage_textures;
-    metadata->numStorageBuffers = num_storage_buffers;
-    metadata->numUniformBuffers = num_uniform_buffers;
+    metadata->num_samplers = num_texture_samplers;
+    metadata->num_storage_textures = num_storage_textures;
+    metadata->num_storage_buffers = num_storage_buffers;
+    metadata->num_uniform_buffers = num_uniform_buffers;
     return true;
 }
 
@@ -1910,18 +1910,18 @@ bool SDL_ShaderCross_ReflectComputeSPIRV(
     }
 
     // Threadcount
-    metadata->threadCountX = spvc_compiler_get_execution_mode_argument_by_index(compiler, SpvExecutionModeLocalSize, 0);
-    metadata->threadCountY = spvc_compiler_get_execution_mode_argument_by_index(compiler, SpvExecutionModeLocalSize, 1);
-    metadata->threadCountZ = spvc_compiler_get_execution_mode_argument_by_index(compiler, SpvExecutionModeLocalSize, 2);
+    metadata->threadcount_x = spvc_compiler_get_execution_mode_argument_by_index(compiler, SpvExecutionModeLocalSize, 0);
+    metadata->threadcount_y = spvc_compiler_get_execution_mode_argument_by_index(compiler, SpvExecutionModeLocalSize, 1);
+    metadata->threadcount_z = spvc_compiler_get_execution_mode_argument_by_index(compiler, SpvExecutionModeLocalSize, 2);
 
     spvc_context_destroy(context);
 
-    metadata->numSamplers = num_texture_samplers;
-    metadata->numReadOnlyStorageTextures = num_readonly_storage_textures;
-    metadata->numReadOnlyStorageBuffers = num_readonly_storage_buffers;
-    metadata->numReadWriteStorageTextures = num_readwrite_storage_textures;
-    metadata->numReadWriteStorageBuffers = num_readwrite_storage_buffers;
-    metadata->numUniformBuffers = num_uniform_buffers;
+    metadata->num_samplers = num_texture_samplers;
+    metadata->num_readonly_storage_textures = num_readonly_storage_textures;
+    metadata->num_readonly_storage_buffers = num_readonly_storage_buffers;
+    metadata->num_readwrite_storage_textures = num_readwrite_storage_textures;
+    metadata->num_readwrite_storage_buffers = num_readwrite_storage_buffers;
+    metadata->num_uniform_buffers = num_uniform_buffers;
     return true;
 }
 
@@ -1950,9 +1950,9 @@ static void *SDL_ShaderCross_INTERNAL_CompileFromSPIRV(
     SPIRVTranspileContext *transpileContext = SDL_ShaderCross_INTERNAL_TranspileFromSPIRV(
         backend,
         shadermodel,
-        info->shaderStage,
+        info->shader_stage,
         info->bytecode,
-        info->bytecodeSize,
+        info->bytecode_size,
         info->entrypoint);
 
     if (transpileContext == NULL) {
@@ -1961,34 +1961,34 @@ static void *SDL_ShaderCross_INTERNAL_CompileFromSPIRV(
 
     void *shaderObject = NULL;
 
-    if (info->shaderStage == SDL_SHADERCROSS_SHADERSTAGE_COMPUTE) {
+    if (info->shader_stage == SDL_SHADERCROSS_SHADERSTAGE_COMPUTE) {
         SDL_GPUComputePipelineCreateInfo createInfo;
         SDL_ShaderCross_ComputePipelineMetadata *pipelineInfo = (SDL_ShaderCross_ComputePipelineMetadata *)metadata;
         SDL_ShaderCross_ReflectComputeSPIRV(
             info->bytecode,
-            info->bytecodeSize,
+            info->bytecode_size,
             pipelineInfo);
         createInfo.entrypoint = transpileContext->cleansed_entrypoint;
         createInfo.format = targetFormat;
         createInfo.props = 0;
-        createInfo.num_samplers = pipelineInfo->numSamplers;
-        createInfo.num_readonly_storage_textures = pipelineInfo->numReadOnlyStorageTextures;
-        createInfo.num_readonly_storage_buffers = pipelineInfo->numReadOnlyStorageBuffers;
-        createInfo.num_readwrite_storage_textures = pipelineInfo->numReadWriteStorageTextures;
-        createInfo.num_readwrite_storage_buffers = pipelineInfo->numReadWriteStorageBuffers;
-        createInfo.num_uniform_buffers = pipelineInfo->numUniformBuffers;
-        createInfo.threadcount_x = pipelineInfo->threadCountX;
-        createInfo.threadcount_y = pipelineInfo->threadCountY;
-        createInfo.threadcount_z = pipelineInfo->threadCountZ;
+        createInfo.num_samplers = pipelineInfo->num_samplers;
+        createInfo.num_readonly_storage_textures = pipelineInfo->num_readonly_storage_textures;
+        createInfo.num_readonly_storage_buffers = pipelineInfo->num_readonly_storage_buffers;
+        createInfo.num_readwrite_storage_textures = pipelineInfo->num_readwrite_storage_textures;
+        createInfo.num_readwrite_storage_buffers = pipelineInfo->num_readwrite_storage_buffers;
+        createInfo.num_uniform_buffers = pipelineInfo->num_uniform_buffers;
+        createInfo.threadcount_x = pipelineInfo->threadcount_x;
+        createInfo.threadcount_y = pipelineInfo->threadcount_y;
+        createInfo.threadcount_z = pipelineInfo->threadcount_z;
 
         SDL_ShaderCross_HLSL_Info hlslInfo;
-        hlslInfo.hlslSource = transpileContext->translated_source;
+        hlslInfo.source = transpileContext->translated_source;
         hlslInfo.entrypoint = transpileContext->cleansed_entrypoint;
-        hlslInfo.includeDir = NULL;
+        hlslInfo.include_dir = NULL;
         hlslInfo.defines = NULL;
-        hlslInfo.numDefines = 0;
-        hlslInfo.enableDebug = info->enableDebug;
-        hlslInfo.shaderStage = SDL_SHADERCROSS_SHADERSTAGE_COMPUTE;
+        hlslInfo.num_defines = 0;
+        hlslInfo.enable_debug = info->enable_debug;
+        hlslInfo.shader_stage = SDL_SHADERCROSS_SHADERSTAGE_COMPUTE;
         hlslInfo.name = info->name;
         hlslInfo.props = 0;
 
@@ -2012,25 +2012,25 @@ static void *SDL_ShaderCross_INTERNAL_CompileFromSPIRV(
         SDL_ShaderCross_GraphicsShaderMetadata *shaderInfo = (SDL_ShaderCross_GraphicsShaderMetadata *)metadata;
         SDL_ShaderCross_ReflectGraphicsSPIRV(
             info->bytecode,
-            info->bytecodeSize,
+            info->bytecode_size,
             shaderInfo);
         createInfo.entrypoint = transpileContext->cleansed_entrypoint;
         createInfo.format = targetFormat;
-        createInfo.stage = (SDL_GPUShaderStage)info->shaderStage;
+        createInfo.stage = (SDL_GPUShaderStage)info->shader_stage;
         createInfo.props = 0;
-        createInfo.num_samplers = shaderInfo->numSamplers;
-        createInfo.num_storage_textures = shaderInfo->numStorageTextures;
-        createInfo.num_storage_buffers = shaderInfo->numStorageBuffers;
-        createInfo.num_uniform_buffers = shaderInfo->numUniformBuffers;
+        createInfo.num_samplers = shaderInfo->num_samplers;
+        createInfo.num_storage_textures = shaderInfo->num_storage_textures;
+        createInfo.num_storage_buffers = shaderInfo->num_storage_buffers;
+        createInfo.num_uniform_buffers = shaderInfo->num_uniform_buffers;
 
         SDL_ShaderCross_HLSL_Info hlslInfo;
-        hlslInfo.hlslSource = transpileContext->translated_source;
+        hlslInfo.source = transpileContext->translated_source;
         hlslInfo.entrypoint = transpileContext->cleansed_entrypoint;
-        hlslInfo.includeDir = NULL;
+        hlslInfo.include_dir = NULL;
         hlslInfo.defines = NULL;
-        hlslInfo.numDefines = 0;
-        hlslInfo.enableDebug = info->enableDebug;
-        hlslInfo.shaderStage = info->shaderStage;
+        hlslInfo.num_defines = 0;
+        hlslInfo.enable_debug = info->enable_debug;
+        hlslInfo.shader_stage = info->shader_stage;
         hlslInfo.name = info->name;
         hlslInfo.props = 0;
 
@@ -2061,9 +2061,9 @@ void *SDL_ShaderCross_TranspileMSLFromSPIRV(
     SPIRVTranspileContext *context = SDL_ShaderCross_INTERNAL_TranspileFromSPIRV(
         SPVC_BACKEND_MSL,
         0,
-        info->shaderStage,
+        info->shader_stage,
         info->bytecode,
-        info->bytecodeSize,
+        info->bytecode_size,
         info->entrypoint
     );
 
@@ -2085,9 +2085,9 @@ void *SDL_ShaderCross_TranspileHLSLFromSPIRV(
     SPIRVTranspileContext *context = SDL_ShaderCross_INTERNAL_TranspileFromSPIRV(
         SPVC_BACKEND_HLSL,
         60,
-        info->shaderStage,
+        info->shader_stage,
         info->bytecode,
-        info->bytecodeSize,
+        info->bytecode_size,
         info->entrypoint
     );
 
@@ -2110,9 +2110,9 @@ void *SDL_ShaderCross_CompileDXBCFromSPIRV(
     SPIRVTranspileContext *context = SDL_ShaderCross_INTERNAL_TranspileFromSPIRV(
         SPVC_BACKEND_HLSL,
         51,
-        info->shaderStage,
+        info->shader_stage,
         info->bytecode,
-        info->bytecodeSize,
+        info->bytecode_size,
         info->entrypoint);
 
     if (context == NULL) {
@@ -2120,13 +2120,13 @@ void *SDL_ShaderCross_CompileDXBCFromSPIRV(
     }
 
     SDL_ShaderCross_HLSL_Info hlslInfo;
-    hlslInfo.hlslSource = context->translated_source;
+    hlslInfo.source = context->translated_source;
     hlslInfo.entrypoint = context->cleansed_entrypoint;
-    hlslInfo.includeDir = NULL;
+    hlslInfo.include_dir = NULL;
     hlslInfo.defines = NULL;
-    hlslInfo.numDefines = 0;
-    hlslInfo.shaderStage = info->shaderStage;
-    hlslInfo.enableDebug = info->enableDebug;
+    hlslInfo.num_defines = 0;
+    hlslInfo.shader_stage = info->shader_stage;
+    hlslInfo.enable_debug = info->enable_debug;
     hlslInfo.name = info->name;
     hlslInfo.props = 0;
 
@@ -2151,9 +2151,9 @@ void *SDL_ShaderCross_CompileDXILFromSPIRV(
     SPIRVTranspileContext *context = SDL_ShaderCross_INTERNAL_TranspileFromSPIRV(
         SPVC_BACKEND_HLSL,
         60,
-        info->shaderStage,
+        info->shader_stage,
         info->bytecode,
-        info->bytecodeSize,
+        info->bytecode_size,
         info->entrypoint);
 
     if (context == NULL) {
@@ -2161,13 +2161,13 @@ void *SDL_ShaderCross_CompileDXILFromSPIRV(
     }
 
     SDL_ShaderCross_HLSL_Info hlslInfo;
-    hlslInfo.hlslSource = context->translated_source;
+    hlslInfo.source = context->translated_source;
     hlslInfo.entrypoint = context->cleansed_entrypoint;
-    hlslInfo.includeDir = NULL;
+    hlslInfo.include_dir = NULL;
     hlslInfo.defines = NULL;
-    hlslInfo.numDefines = 0;
-    hlslInfo.shaderStage = info->shaderStage;
-    hlslInfo.enableDebug = info->enableDebug;
+    hlslInfo.num_defines = 0;
+    hlslInfo.shader_stage = info->shader_stage;
+    hlslInfo.enable_debug = info->enable_debug;
     hlslInfo.name = info->name;
     hlslInfo.props = 0;
 
@@ -2189,45 +2189,45 @@ static void *SDL_ShaderCross_INTERNAL_CreateShaderFromSPIRV(
     SDL_GPUShaderFormat shader_formats = SDL_GetGPUShaderFormats(device);
 
     if (shader_formats & SDL_GPU_SHADERFORMAT_SPIRV) {
-        if (info->shaderStage == SDL_SHADERCROSS_SHADERSTAGE_COMPUTE) {
+        if (info->shader_stage == SDL_SHADERCROSS_SHADERSTAGE_COMPUTE) {
             SDL_GPUComputePipelineCreateInfo createInfo;
             SDL_ShaderCross_ComputePipelineMetadata *pipelineMetadata = (SDL_ShaderCross_ComputePipelineMetadata *)metadata;
             SDL_ShaderCross_ReflectComputeSPIRV(
                 info->bytecode,
-                info->bytecodeSize,
+                info->bytecode_size,
                 pipelineMetadata);
             createInfo.code = info->bytecode;
-            createInfo.code_size = info->bytecodeSize;
+            createInfo.code_size = info->bytecode_size;
             createInfo.entrypoint = info->entrypoint;
             createInfo.format = SDL_GPU_SHADERFORMAT_SPIRV;
             createInfo.props = 0;
-            createInfo.num_samplers = pipelineMetadata->numSamplers;
-            createInfo.num_readonly_storage_textures = pipelineMetadata->numReadOnlyStorageTextures;
-            createInfo.num_readonly_storage_buffers = pipelineMetadata->numReadOnlyStorageBuffers;
-            createInfo.num_readwrite_storage_textures = pipelineMetadata->numReadWriteStorageTextures;
-            createInfo.num_readwrite_storage_buffers = pipelineMetadata->numReadWriteStorageBuffers;
-            createInfo.num_uniform_buffers = pipelineMetadata->numUniformBuffers;
-            createInfo.threadcount_x = pipelineMetadata->threadCountX;
-            createInfo.threadcount_y = pipelineMetadata->threadCountY;
-            createInfo.threadcount_z = pipelineMetadata->threadCountZ;
+            createInfo.num_samplers = pipelineMetadata->num_samplers;
+            createInfo.num_readonly_storage_textures = pipelineMetadata->num_readonly_storage_textures;
+            createInfo.num_readonly_storage_buffers = pipelineMetadata->num_readonly_storage_buffers;
+            createInfo.num_readwrite_storage_textures = pipelineMetadata->num_readwrite_storage_textures;
+            createInfo.num_readwrite_storage_buffers = pipelineMetadata->num_readwrite_storage_buffers;
+            createInfo.num_uniform_buffers = pipelineMetadata->num_uniform_buffers;
+            createInfo.threadcount_x = pipelineMetadata->threadcount_x;
+            createInfo.threadcount_y = pipelineMetadata->threadcount_y;
+            createInfo.threadcount_z = pipelineMetadata->threadcount_z;
             return SDL_CreateGPUComputePipeline(device, &createInfo);
         } else {
             SDL_GPUShaderCreateInfo createInfo;
             SDL_ShaderCross_GraphicsShaderMetadata *shaderMetadata = (SDL_ShaderCross_GraphicsShaderMetadata *)metadata;
             SDL_ShaderCross_ReflectGraphicsSPIRV(
                 info->bytecode,
-                info->bytecodeSize,
+                info->bytecode_size,
                 shaderMetadata);
             createInfo.code = info->bytecode;
-            createInfo.code_size = info->bytecodeSize;
+            createInfo.code_size = info->bytecode_size;
             createInfo.entrypoint = info->entrypoint;
             createInfo.format = SDL_GPU_SHADERFORMAT_SPIRV;
-            createInfo.stage = (SDL_GPUShaderStage)info->shaderStage;
+            createInfo.stage = (SDL_GPUShaderStage)info->shader_stage;
             createInfo.props = 0;
-            createInfo.num_samplers = shaderMetadata->numSamplers;
-            createInfo.num_storage_textures = shaderMetadata->numStorageTextures;
-            createInfo.num_storage_buffers = shaderMetadata->numStorageBuffers;
-            createInfo.num_uniform_buffers = shaderMetadata->numUniformBuffers;
+            createInfo.num_samplers = shaderMetadata->num_samplers;
+            createInfo.num_storage_textures = shaderMetadata->num_storage_textures;
+            createInfo.num_storage_buffers = shaderMetadata->num_storage_buffers;
+            createInfo.num_uniform_buffers = shaderMetadata->num_uniform_buffers;
             return SDL_CreateGPUShader(device, &createInfo);
         }
     } else if (shader_formats & SDL_GPU_SHADERFORMAT_MSL) {

--- a/src/cli.c
+++ b/src/cli.c
@@ -54,11 +54,11 @@ void write_graphics_reflect_json(SDL_IOStream *outputIO, SDL_ShaderCross_Graphic
 {
     SDL_IOprintf(
         outputIO,
-        "{ \"samplers\": %u, \"storageTextures\": %u, \"storageBuffers\": %u, \"uniformBuffers\": %u }\n",
-        info->numSamplers,
-        info->numStorageTextures,
-        info->numStorageBuffers,
-        info->numUniformBuffers
+        "{ \"samplers\": %u, \"storage_textures\": %u, \"storage_buffers\": %u, \"uniform_buffers\": %u }\n",
+        info->num_samplers,
+        info->num_storage_textures,
+        info->num_storage_buffers,
+        info->num_uniform_buffers
     );
 }
 
@@ -66,16 +66,16 @@ void write_compute_reflect_json(SDL_IOStream *outputIO, SDL_ShaderCross_ComputeP
 {
     SDL_IOprintf(
         outputIO,
-        "{ \"samplers\": %u, \"readOnlyStorageTextures\": %u, \"readOnlyStorageBuffers\": %u, \"readWriteStorageTextures\": %u, \"readWriteStorageBuffers\": %u, \"uniformBuffers\": %u, \"threadCountX\": %u, \"threadCountY\": %u, \"threadCountZ\": %u }\n",
-        info->numSamplers,
-        info->numReadOnlyStorageTextures,
-        info->numReadOnlyStorageBuffers,
-        info->numReadWriteStorageTextures,
-        info->numReadWriteStorageBuffers,
-        info->numUniformBuffers,
-        info->threadCountX,
-        info->threadCountY,
-        info->threadCountZ
+        "{ \"samplers\": %u, \"readonly_storage_textures\": %u, \"readonly_storage_buffers\": %u, \"readwrite_storage_textures\": %u, \"readwrite_storage_buffers\": %u, \"uniform_buffers\": %u, \"threadcount_x\": %u, \"threadcount_y\": %u, \"threadcount_z\": %u }\n",
+        info->num_samplers,
+        info->num_readonly_storage_textures,
+        info->num_readonly_storage_buffers,
+        info->num_readwrite_storage_textures,
+        info->num_readwrite_storage_buffers,
+        info->num_uniform_buffers,
+        info->threadcount_x,
+        info->threadcount_y,
+        info->threadcount_z
     );
 }
 
@@ -309,10 +309,10 @@ int main(int argc, char *argv[])
     if (spirvSource) {
         SDL_ShaderCross_SPIRV_Info spirvInfo;
         spirvInfo.bytecode = fileData;
-        spirvInfo.bytecodeSize = fileSize;
+        spirvInfo.bytecode_size = fileSize;
         spirvInfo.entrypoint = entrypointName;
-        spirvInfo.shaderStage = shaderStage;
-        spirvInfo.enableDebug = enableDebug;
+        spirvInfo.shader_stage = shaderStage;
+        spirvInfo.enable_debug = enableDebug;
         spirvInfo.name = filename;
         spirvInfo.props = 0;
 
@@ -412,13 +412,13 @@ int main(int argc, char *argv[])
         }
     } else {
         SDL_ShaderCross_HLSL_Info hlslInfo;
-        hlslInfo.hlslSource = fileData;
+        hlslInfo.source = fileData;
         hlslInfo.entrypoint = entrypointName;
-        hlslInfo.includeDir = includeDir;
+        hlslInfo.include_dir = includeDir;
         hlslInfo.defines = defines;
-        hlslInfo.numDefines = numDefines;
-        hlslInfo.shaderStage = shaderStage;
-        hlslInfo.enableDebug = enableDebug;
+        hlslInfo.num_defines = numDefines;
+        hlslInfo.shader_stage = shaderStage;
+        hlslInfo.enable_debug = enableDebug;
         hlslInfo.name = filename;
         hlslInfo.props = 0;
 
@@ -462,10 +462,10 @@ int main(int argc, char *argv[])
                 } else {
                     SDL_ShaderCross_SPIRV_Info spirvInfo;
                     spirvInfo.bytecode = spirv;
-                    spirvInfo.bytecodeSize = bytecodeSize;
+                    spirvInfo.bytecode_size = bytecodeSize;
                     spirvInfo.entrypoint = entrypointName;
-                    spirvInfo.shaderStage = shaderStage;
-                    spirvInfo.enableDebug = enableDebug;
+                    spirvInfo.shader_stage = shaderStage;
+                    spirvInfo.enable_debug = enableDebug;
                     spirvInfo.props = 0;
                     char *buffer = SDL_ShaderCross_TranspileMSLFromSPIRV(
                         &spirvInfo);
@@ -508,10 +508,10 @@ int main(int argc, char *argv[])
 
                 SDL_ShaderCross_SPIRV_Info spirvInfo;
                 spirvInfo.bytecode = spirv;
-                spirvInfo.bytecodeSize = bytecodeSize;
+                spirvInfo.bytecode_size = bytecodeSize;
                 spirvInfo.entrypoint = entrypointName;
-                spirvInfo.shaderStage = shaderStage;
-                spirvInfo.enableDebug = enableDebug;
+                spirvInfo.shader_stage = shaderStage;
+                spirvInfo.enable_debug = enableDebug;
                 spirvInfo.props = 0;
 
                 char *buffer = SDL_ShaderCross_TranspileHLSLFromSPIRV(

--- a/src/cli.c
+++ b/src/cli.c
@@ -313,6 +313,7 @@ int main(int argc, char *argv[])
         spirvInfo.entrypoint = entrypointName;
         spirvInfo.shaderStage = shaderStage;
         spirvInfo.enableDebug = enableDebug;
+        spirvInfo.name = filename;
         spirvInfo.props = 0;
 
         switch (destinationFormat) {
@@ -418,6 +419,7 @@ int main(int argc, char *argv[])
         hlslInfo.numDefines = numDefines;
         hlslInfo.shaderStage = shaderStage;
         hlslInfo.enableDebug = enableDebug;
+        hlslInfo.name = filename;
         hlslInfo.props = 0;
 
         switch (destinationFormat) {


### PR DESCRIPTION
For future-proofing the API now takes info structs with a SDL_PropertiesID for extensions.

This PR also adds shader debug info support and source debugging in HLSL -> SPIR-V debug workflows in RenderDoc should work out of the box now.

Resolves #64 
Resolves #66 
Supersedes #65 