### PR TITLE
Add PropertiesID field to Metadata structs

### DIFF
--- a/include/SDL3_shadercross/SDL_shadercross.h
+++ b/include/SDL3_shadercross/SDL_shadercross.h
@@ -51,6 +51,8 @@ typedef struct SDL_ShaderCross_GraphicsShaderMetadata
     Uint32 num_storage_textures;  /**< The number of storage textures defined in the shader. */
     Uint32 num_storage_buffers;   /**< The number of storage buffers defined in the shader. */
     Uint32 num_uniform_buffers;   /**< The number of uniform buffers defined in the shader. */
+
+    SDL_PropertiesID props;       /**< A properties ID for extensions. This is allocated and freed by the caller, and should be 0 if no extensions are needed. */
 } SDL_ShaderCross_GraphicsShaderMetadata;
 
 typedef struct SDL_ShaderCross_ComputePipelineMetadata
@@ -64,6 +66,8 @@ typedef struct SDL_ShaderCross_ComputePipelineMetadata
     Uint32 threadcount_x;                   /**< The number of threads in the X dimension. */
     Uint32 threadcount_y;                   /**< The number of threads in the Y dimension. */
     Uint32 threadcount_z;                   /**< The number of threads in the Z dimension. */
+
+    SDL_PropertiesID props;                 /**< A properties ID for extensions. This is allocated and freed by the caller, and should be 0 if no extensions are needed. */
 } SDL_ShaderCross_ComputePipelineMetadata;
 
 typedef struct SDL_ShaderCross_SPIRV_Info

--- a/src/cli.c
+++ b/src/cli.c
@@ -400,6 +400,7 @@ int main(int argc, char *argv[])
             case SHADERFORMAT_JSON: {
                 if (shaderStage == SDL_SHADERCROSS_SHADERSTAGE_COMPUTE) {
                     SDL_ShaderCross_ComputePipelineMetadata info;
+                    info.props = 0;
                     if (SDL_ShaderCross_ReflectComputeSPIRV(
                         fileData,
                         fileSize,
@@ -411,6 +412,7 @@ int main(int argc, char *argv[])
                     }
                 } else {
                     SDL_ShaderCross_GraphicsShaderMetadata info;
+                    info.props = 0;
                     if (SDL_ShaderCross_ReflectGraphicsSPIRV(
                         fileData,
                         fileSize,
@@ -561,6 +563,7 @@ int main(int argc, char *argv[])
 
                 if (shaderStage == SDL_SHADERCROSS_SHADERSTAGE_COMPUTE) {
                     SDL_ShaderCross_ComputePipelineMetadata info;
+                    info.props = 0;
                     bool result = SDL_ShaderCross_ReflectComputeSPIRV(
                         spirv,
                         bytecodeSize,
@@ -575,6 +578,7 @@ int main(int argc, char *argv[])
                     }
                 } else {
                     SDL_ShaderCross_GraphicsShaderMetadata info;
+                    info.props = 0;
                     bool result = SDL_ShaderCross_ReflectGraphicsSPIRV(
                         spirv,
                         bytecodeSize,


### PR DESCRIPTION
Not much to see here, except one detail: The rest of the metadata struct does not have to be initialized since it's _mostly_ an out struct, but the only way Properties will work here is if that one field is initialized first. The idea is that shadercross would check `props` for known metadata extensions, then fill in the properties found when applicable.

Kind of weird but it does work - if we still don't want to do this we can just call this `WONTFIX`.

Fixes #72