### PR TITLE
Fix args counting during gathering of args for DXC compiler

### DIFF
--- a/src/SDL_shadercross.c
+++ b/src/SDL_shadercross.c
@@ -418,9 +418,8 @@ static void *SDL_ShaderCross_INTERNAL_CompileUsingDXC(
             SDL_free(entryPointUtf16);
             return NULL;
         }
-        args[2] = (LPCWSTR)L"-I";
-        args[3] = includeDirUtf16;
-        argCount += 2;
+        args[argCount++] = (LPCWSTR)L"-I";
+        args[argCount++] = includeDirUtf16;
     }
 
     source.Ptr = info->source;


### PR DESCRIPTION
Fixing bug in `SDL_ShaderCross_INTERNAL_CompileUsingDXC` - it's not using `argCount` when writing in include dir parameters in the `args` array.

Can be reproduced by trying to compile HLSL file with both define strings and includeDir