### PR TITLE
Add SDL_SHADERCROSS_PROP_SPIRV_PSSL_COMPATIBILITY property

### DIFF
--- a/include/SDL3_shadercross/SDL_shadercross.h
+++ b/include/SDL3_shadercross/SDL_shadercross.h
@@ -82,6 +82,8 @@ typedef struct SDL_ShaderCross_SPIRV_Info
     SDL_PropertiesID props;                    /**< A properties ID for extensions. Should be 0 if no extensions are needed. */
 } SDL_ShaderCross_SPIRV_Info;
 
+#define SDL_SHADERCROSS_PROP_SPIRV_PSSL_COMPATIBILITY "SDL.shadercross.spirv.pssl.compatibility"
+
 typedef struct SDL_ShaderCross_HLSL_Define
 {
     char *name;   /**< The define name. */

--- a/src/SDL_shadercross.c
+++ b/src/SDL_shadercross.c
@@ -894,7 +894,8 @@ static SPIRVTranspileContext *SDL_ShaderCross_INTERNAL_TranspileFromSPIRV(
     SDL_ShaderCross_ShaderStage shaderStage, // only used for MSL
     const Uint8 *code,
     size_t codeSize,
-    const char *entrypoint
+    const char *entrypoint,
+    SDL_PropertiesID props
 ) {
     spvc_result result;
     spvc_context context = NULL;
@@ -940,7 +941,7 @@ static SPIRVTranspileContext *SDL_ShaderCross_INTERNAL_TranspileFromSPIRV(
         spvc_compiler_options_set_uint(options, SPVC_COMPILER_OPTION_HLSL_SHADER_MODEL, shadermodel);
         spvc_compiler_options_set_uint(options, SPVC_COMPILER_OPTION_HLSL_NONWRITABLE_UAV_TEXTURE_AS_SRV, 1);
         spvc_compiler_options_set_uint(options, SPVC_COMPILER_OPTION_HLSL_FLATTEN_MATRIX_VERTEX_INPUT_SEMANTICS, 1);
-        spvc_compiler_options_set_bool(options, SPVC_COMPILER_OPTION_HLSL_USE_ENTRY_POINT_NAME, true);
+        spvc_compiler_options_set_bool(options, SPVC_COMPILER_OPTION_HLSL_USE_ENTRY_POINT_NAME, !SDL_GetBooleanProperty(props, SDL_SHADERCROSS_PROP_SPIRV_PSSL_COMPATIBILITY, false));
         spvc_compiler_options_set_bool(options, SPVC_COMPILER_OPTION_HLSL_POINT_SIZE_COMPAT, true);
     }
 
@@ -2013,7 +2014,8 @@ static void *SDL_ShaderCross_INTERNAL_CompileFromSPIRV(
         info->shader_stage,
         info->bytecode,
         info->bytecode_size,
-        info->entrypoint);
+        info->entrypoint,
+        info->props);
 
     if (transpileContext == NULL) {
         return NULL;
@@ -2140,7 +2142,8 @@ void *SDL_ShaderCross_TranspileMSLFromSPIRV(
         info->shader_stage,
         info->bytecode,
         info->bytecode_size,
-        info->entrypoint
+        info->entrypoint,
+        info->props
     );
 
     if (context == NULL) {
@@ -2160,11 +2163,12 @@ void *SDL_ShaderCross_TranspileHLSLFromSPIRV(
 {
     SPIRVTranspileContext *context = SDL_ShaderCross_INTERNAL_TranspileFromSPIRV(
         SPVC_BACKEND_HLSL,
-        60,
+        SDL_GetBooleanProperty(info->props, SDL_SHADERCROSS_PROP_SPIRV_PSSL_COMPATIBILITY, false) ? 50 : 60,
         info->shader_stage,
         info->bytecode,
         info->bytecode_size,
-        info->entrypoint
+        info->entrypoint,
+        info->props
     );
 
     if (context == NULL) {
@@ -2189,7 +2193,8 @@ void *SDL_ShaderCross_CompileDXBCFromSPIRV(
         info->shader_stage,
         info->bytecode,
         info->bytecode_size,
-        info->entrypoint);
+        info->entrypoint,
+        info->props);
 
     if (context == NULL) {
         return NULL;
@@ -2229,7 +2234,8 @@ void *SDL_ShaderCross_CompileDXILFromSPIRV(
         info->shader_stage,
         info->bytecode,
         info->bytecode_size,
-        info->entrypoint);
+        info->entrypoint,
+        info->props);
 
     if (context == NULL) {
         return NULL;


### PR DESCRIPTION
The HLSL emitted by shadercross comes very close to being compatible with Sony's [PSSL](https://ubm-twvideo01.s3.amazonaws.com/o1/vault/gdceurope2013/Presentations/825424RichardStenson.pdf), except it needs to use an even lower shader model version than our DXBC path and it's easier to use `main()` rather than custom entry point names, at least in SDL-playstation's case. With this property we can use upstream shadercross with our PS repo!

Mostly needs style/namespace checking.