### PR TITLE
Fixed typo in cmake config script

### DIFF
--- a/cmake/SDL3_shadercrossConfig.cmake.in
+++ b/cmake/SDL3_shadercrossConfig.cmake.in
@@ -66,7 +66,7 @@ endfunction()
 
 # Make sure SDL3_shadercross::SDL3_shadercross always exists
 if(NOT TARGET SDL3_shadercross::SDL3_shadercross)
-    if(TARGET SDL3_shadercross::SDL3_shadercross)
+    if(TARGET SDL3_shadercross::SDL3_shadercross-shared)
         _sdl_create_target_alias_compat(SDL3_shadercross::SDL3_shadercross SDL3_shadercross::SDL3_shadercross-shared)
     elseif(TARGET SDL3_shadercross::SDL3_shadercross-static)
         _sdl_create_target_alias_compat(SDL3_shadercross::SDL3_shadercross SDL3_shadercross::SDL3_shadercross-static)


### PR DESCRIPTION
I'm 99% certain there was a typo toward the bottom of the cmake config script where instead of checking for the existence of the shared library target, it was checking for the existence of SDL3_shadercross::SDL3_shadercross again, which was a condition that would effectively never evaluate to true and would also result in SDL3_shadercross::SDL3_shadercross always aliasing to the static target. This change makes it so that the presumably intended behavior (aliasing to the shared target if it exists, and to the static target otherwise) is restored.