### PR TITLE
Distinguish between HLSL compile errors and warnings.

### DIFF
--- a/src/SDL_shadercross.c
+++ b/src/SDL_shadercross.c
@@ -529,9 +529,11 @@ static void *SDL_ShaderCross_INTERNAL_CompileUsingDXC(
         (void **)&errors,
         NULL);
 
+    *size = blob->lpVtbl->GetBufferSize(blob);
     if (errors != NULL && errors->lpVtbl->GetBufferSize(errors) != 0) {
         char *message = (char *)errors->lpVtbl->GetBufferPointer(errors);
-        if (SDL_strstr(message, "error:")) {
+        // If no compiled blob was returned, it was an error.
+        if (*size == 0) {
             SDL_SetError("HLSL compilation failed: %s", message);
             dxcResult->lpVtbl->Release(dxcResult);
             dxcInstance->lpVtbl->Release(dxcInstance);
@@ -542,7 +544,6 @@ static void *SDL_ShaderCross_INTERNAL_CompileUsingDXC(
         }
     }
 
-    *size = blob->lpVtbl->GetBufferSize(blob);
     void *buffer = SDL_malloc(*size);
     SDL_memcpy(buffer, blob->lpVtbl->GetBufferPointer(blob), *size);
 


### PR DESCRIPTION
HLSL compilation can succeed but report errors; the resulting shader isn't usable so in this case we should return an error.

This addresses #125 