### PR TITLE
Call GetStatus on IDxcResult to check for compilation errors

### DIFF
--- a/src/SDL_shadercross.c
+++ b/src/SDL_shadercross.c
@@ -497,7 +497,9 @@ static void *SDL_ShaderCross_INTERNAL_CompileUsingDXC(
                                        IID_IDxcBlob,
                                        (void **)&blob,
                                        NULL);
-    if (ret < 0) {
+
+    HRESULT retStatus;
+    if (ret < 0 || dxcResult->lpVtbl->GetStatus(dxcResult, &retStatus) < 0 || retStatus < 0 ) {
         // Compilation failed, display errors
         dxcResult->lpVtbl->GetOutput(
             dxcResult,


### PR DESCRIPTION
This fixes https://github.com/libsdl-org/SDL_shadercross/issues/125, using the error handling from the DXC wiki https://github.com/microsoft/DirectXShaderCompiler/wiki/Advanced-Error-Handling

It now fails on errors, but warnings do not affect the exit code of shadercross.