### PR TITLE
Require Vulkan 1.1 for wave intrinsics

### DIFF
--- a/src/SDL_shadercross.c
+++ b/src/SDL_shadercross.c
@@ -440,6 +440,7 @@ static void *SDL_ShaderCross_INTERNAL_CompileUsingDXC(
     if (spirv) {
         args[argCount++] = (LPCWSTR)L"-spirv";
         args[argCount++] = (LPCWSTR)L"-fspv-flatten-resource-arrays";
+        args[argCount++] = (LPCWSTR)L"-fspv-target-env=vulkan1.1";
     }
 
     if (info->enable_debug) {


### PR DESCRIPTION
Shader Model 6.0 has support for GPU features such as wave intrinsics, e.g. `WaveGetLaneCount`, `WaveActiveSum` and `WaveGetLaneIndex`. Shadercross currently compiles HLSL shaders for SM 6.0:

https://github.com/libsdl-org/SDL_shadercross/blob/a3aad1ced336ae18f0efc00fd48568f1954775f4/src/SDL_shadercross.c#L429-L438

In order to support cross-compilation of HLSL shaders utilising these features to SPIR-V, spirv-cross requires a minimum of Vulkan 1.1. If this is not set explicitly, it will complain and refuse to compile the shader - this currently makes wave intrinsics unusable.

In order to specify the target environment, we need to pass `-fspv-target-env` as a command line parameter to spirv-cross. This PR passes Vulkan 1.1 as the target environment when compiling to SPIR-V, to support these Shader Model 6.0 features.

I have tested this support with [b0nes164's implementation](https://github.com/b0nes164/GPUPrefixSums/tree/98d93a4e9ed2f3c8353119515bf9be90a2e137ad/GPUPrefixSumsD3D12) of GPU Prefix Sum, which utilizes wave intrinsics, and with Vulkan 1.1 required, these shaders compile to SPIR-V and execute successfully.