### PR TITLE
Use DirectXShaderCompiler 1.8.2502 with backported CMake 4.0 support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -12,5 +12,5 @@
 	branch = main
 [submodule "DirectXShaderCompiler"]
 	path = external/DirectXShaderCompiler
-	url = https://github.com/microsoft/DirectXShaderCompiler.git
-	branch = main
+	url = https://github.com/libsdl-org/DirectXShaderCompiler.git
+	branch = 1.8.2502-SDL


### PR DESCRIPTION
Looks like this "older" February release compiles hlsl correctly.

To fix CMake 4.0 support, I created a [libsdl-org/DirectXShaderCompiler](https://github.com/libsdl-org/DirectXShaderCompiler) fork
/cc @slouken

@sezero : do you have scripts to keep the libsdl-org forks up-to-date with upstream?

For #152