### PR TITLE
build-scripts: bump pre-built DirectXShaderCompiler binaries to 2025_05_24

### DIFF
--- a/build-scripts/download-prebuilt-DirectXShaderCompiler.cmake
+++ b/build-scripts/download-prebuilt-DirectXShaderCompiler.cmake
@@ -1,7 +1,7 @@
-set(DXC_LINUX_X64_URL "https://github.com/microsoft/DirectXShaderCompiler/releases/download/v1.8.2502/linux_dxc_2025_02_20.x86_64.tar.gz")
-set(DXC_LINUX_X64_HASH "SHA256=e0580d90dbf6053a783ddd8d5153285f0606e5deaad17a7a6452f03acdf88c71")
-set(DXC_WINDOWS_X86_X64_ARM64_URL "https://github.com/microsoft/DirectXShaderCompiler/releases/download/v1.8.2502/dxc_2025_02_20.zip")
-set(DXC_WINDOWS_X86_X64_ARM64_HASH "SHA256=70b1913a1bfce4a3e1a5311d16246f4ecdf3a3e613abec8aa529e57668426f85")
+set(DXC_LINUX_X64_URL "https://github.com/microsoft/DirectXShaderCompiler/releases/download/v1.8.2505/linux_dxc_2025_05_24.x86_64.tar.gz")
+set(DXC_LINUX_X64_HASH "SHA256=b99655f65215287825fcdd49102b17e2a1608eff79ffaf9457514c2676892aa5")
+set(DXC_WINDOWS_X86_X64_ARM64_URL "https://github.com/microsoft/DirectXShaderCompiler/releases/download/v1.8.2505/dxc_2025_05_24.zip")
+set(DXC_WINDOWS_X86_X64_ARM64_HASH "SHA256=81380f3eca156d902d6404fd6df9f4b0886f576ff3e18b2cc10d3075ffc9d119")
 
 get_filename_component(EXTERNAL_PATH "${CMAKE_CURRENT_LIST_DIR}/../external" ABSOLUTE)
 if(NOT DEFINED DXC_ROOT)


### PR DESCRIPTION
This only affects the ci artifacts of the (non-Steam) Linux build, which does not build DirectXShaderCompiler itself.

Manual testing does not show any issues.