### PR TITLE
Fix memory leak when vkd3d-utils is missing or too old

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         platform:
-          - { name: Windows (MSVC),                os: windows-2019,   build-spirv-cross: true,  vendored: false, shell: sh, msvc: true, artifact: 'SDL3_shadercross-VC-x64' }
+          - { name: Windows (MSVC),                os: windows-latest, build-spirv-cross: true,  vendored: false, shell: sh, msvc: true, artifact: 'SDL3_shadercross-VC-x64' }
           - { name: Windows (mingw64),             os: windows-latest, build-spirv-cross: false, vendored: false, shell: 'msys2 {0}', msystem: mingw64, msys-env: mingw-w64-x86_64, artifact: 'SDL3_shadercross-mingw64' }
           - { name: Ubuntu 22.04,                  os: ubuntu-22.04,   build-spirv-cross: true,  vendored: false, shell: sh, artifact: 'SDL3_shadercross-linux-x64' }
           - { name: Steam Linux Runtime (Sniper),  os: ubuntu-latest,  build-spirv-cross: false,  vendored: true, shell: sh, artifact: 'SDL3_shadercross-slrsniper', container: 'registry.gitlab.steamos.cloud/steamrt/sniper/sdk:latest' }

--- a/src/SDL_shadercross.c
+++ b/src/SDL_shadercross.c
@@ -796,6 +796,7 @@ void *SDL_ShaderCross_INTERNAL_CompileDXBCFromHLSL(
         info->enable_debug);
 
     if (blob == NULL) {
+        SDL_free(transpiledSource);
         *size = 0;
         return NULL;
     }


### PR DESCRIPTION
When missing vkd3d, or using a version that is too old, the following error is shown when transpiling hlsl to dxbc:
```
vkd3d:72183:fixme:hlsl_compile_shader Unknown compilation target "ps_5_1".
ERROR: Failed to compile DXBC from HLSL: HLSL compilation failed for an unknown reason.
Memory allocations:
Allocation 0: 3999 bytes
	0x7f91b05304ad: SDL_malloc_REAL+0x2b
	0x7f91b0476150: SDL_malloc+0x1c
	0x7f91b091ed96: SDL_ShaderCross_TranspileHLSLFromSPIRV+0xee
	0x7f91b091a427: SDL_ShaderCross_INTERNAL_CompileDXBCFromHLSL+0xa6
	0x7f91b091a5db: SDL_ShaderCross_CompileDXBCFromHLSL+0x51
	0x404064: main+0x138c
	0x7f91b024614a: __libc_start_call_main+0x7a
	0x7f91b024620b: __libc_start_main+0x8b
	0x402415: _start+0x25
Total: 3.91 Kb in 1 allocations
```

This PR fixes the leak:
```
vkd3d:72251:fixme:hlsl_compile_shader Unknown compilation target "ps_5_1".
ERROR: Failed to compile DXBC from HLSL: HLSL compilation failed for an unknown reason.
Memory allocations:
Total: 0.00 Kb in 0 allocations
```