### PR TITLE
Remove offset from input reflection

### DIFF
--- a/include/SDL3_shadercross/SDL_shadercross.h
+++ b/include/SDL3_shadercross/SDL_shadercross.h
@@ -63,7 +63,6 @@ typedef enum SDL_ShaderCross_ShaderStage
 typedef struct SDL_ShaderCross_IOVarMetadata {
     char *name;                             /**< The UTF-8 name of the variable. */
     Uint32 location;                        /**< The location of the variable. */
-    Uint32 offset;                          /**< The byte offset of the variable. */
     SDL_ShaderCross_IOVarType vector_type;  /**< The vector type of the variable. */
     Uint32 vector_size;                     /**< The number of components in the vector type of the variable. */
 } SDL_ShaderCross_IOVarMetadata;

--- a/src/SDL_shadercross.c
+++ b/src/SDL_shadercross.c
@@ -1633,7 +1633,6 @@ void SDL_ShaderCross_INTERNAL_GetIOVars(
     SDL_ShaderCross_IOVarMetadata* vars,
     char *name_buffer
 ) {
-    Uint32 offset = 0;
     size_t name_buffer_offset = 0;
     for (size_t i = 0; i < num_vars; i++) {
         SDL_ShaderCross_IOVarMetadata* var = &vars[i];
@@ -1687,8 +1686,6 @@ void SDL_ShaderCross_INTERNAL_GetIOVars(
         SDL_memcpy(var->name, resource->name, length_name);
         name_buffer_offset += length_name;
         var->location = spvc_compiler_get_decoration(compiler, resource->id, SpvDecorationLocation);
-        var->offset = offset;
-        offset += (spvc_type_get_bit_width(type) / 8) * vector_size;
     }
 }
 

--- a/src/cli.c
+++ b/src/cli.c
@@ -181,11 +181,10 @@ void write_graphics_reflect_json(SDL_IOStream *outputIO, SDL_ShaderCross_Graphic
     SDL_IOprintf(outputIO, "\"inputs\": [");
     for (Uint32 i = 0; i < info->num_inputs; i++) {
         const SDL_ShaderCross_IOVarMetadata* input = &info->inputs[i];
-        SDL_IOprintf(outputIO, "{ \"name\": \"%s\", \"type\": \"%s\", \"location\": %u, \"offset\": %u }%s",
+        SDL_IOprintf(outputIO, "{ \"name\": \"%s\", \"type\": \"%s\", \"location\": %u }%s",
             input->name,
             io_var_type_to_string(input->vector_type, input->vector_size),
             input->location,
-            input->offset,
             i + 1 < info->num_inputs ? ", " : ""
         );
     }
@@ -194,11 +193,10 @@ void write_graphics_reflect_json(SDL_IOStream *outputIO, SDL_ShaderCross_Graphic
     SDL_IOprintf(outputIO, "\"outputs\": [");
     for (Uint32 i = 0; i < info->num_outputs; i++) {
         const SDL_ShaderCross_IOVarMetadata* output = &info->outputs[i];
-        SDL_IOprintf(outputIO, "{ \"name\": \"%s\", \"type\": \"%s\", \"location\": %u, \"offset\": %u }%s",
+        SDL_IOprintf(outputIO, "{ \"name\": \"%s\", \"type\": \"%s\", \"location\": %u }%s",
             output->name,
             io_var_type_to_string(output->vector_type, output->vector_size),
             output->location,
-            output->offset,
             i + 1 < info->num_outputs ? ", " : ""
         );
     }


### PR DESCRIPTION
Calculating input offsets is incorrect, this information can't be determined from shader source because the client can choose how the vertex inputs are laid out. For example the client may choose to provide three vertex attributes in three separate buffers. 