### PR TITLE
Do not cull unused bindings and inputs

### DIFF
--- a/src/SDL_shadercross.c
+++ b/src/SDL_shadercross.c
@@ -400,7 +400,7 @@ static void *SDL_ShaderCross_INTERNAL_CompileUsingDXC(
         defineStringsUtf16[i] = (wchar_t *)SDL_iconv_string("WCHAR_T", "UTF-8", defineString, MAX_DEFINE_STRING_LENGTH);
     }
 
-    LPCWSTR *args = SDL_malloc(sizeof(LPCWSTR) * (numDefineStrings + 11));
+    LPCWSTR *args = SDL_malloc(sizeof(LPCWSTR) * (numDefineStrings + 13));
     Uint32 argCount = 0;
 
     for (Uint32 i = 0; i < numDefineStrings; i += 1) {
@@ -443,6 +443,8 @@ static void *SDL_ShaderCross_INTERNAL_CompileUsingDXC(
     if (spirv) {
         args[argCount++] = (LPCWSTR)L"-spirv";
         args[argCount++] = (LPCWSTR)L"-fspv-flatten-resource-arrays";
+        args[argCount++] = (LPCWSTR)L"-fspv-preserve-bindings";
+        args[argCount++] = (LPCWSTR)L"-fspv-preserve-interface";
     }
 
     if (info->enable_debug) {

--- a/src/SDL_shadercross.c
+++ b/src/SDL_shadercross.c
@@ -1710,14 +1710,6 @@ SDL_ShaderCross_GraphicsShaderMetadata * SDL_ShaderCross_ReflectGraphicsSPIRV(
     size_t num_outputs = 0;
     size_t num_separate_samplers = 0; // HLSL edge case
     size_t num_separate_images = 0; // HLSL edge case
-
-    // The client might have unused resources that get optimized out by the compiler.
-    // We output the resource count as the highest binding index + 1 to avoid bindings becoming out of order.
-    Sint32 highest_sampler_binding_index = -1;
-    Sint32 highest_storage_texture_binding_index = -1;
-    Sint32 highest_storage_buffer_binding_index = -1;
-    Sint32 highest_uniform_buffer_binding_index = -1;
-
     (void) metadataProps;
 
     if (code == NULL) {
@@ -1770,11 +1762,6 @@ SDL_ShaderCross_GraphicsShaderMetadata * SDL_ShaderCross_ReflectGraphicsSPIRV(
         return NULL;
     }
 
-    for (size_t i = 0; i < num_texture_samplers; i += 1)
-    {
-        highest_sampler_binding_index = SDL_max(highest_sampler_binding_index, (Sint32) spvc_compiler_get_decoration(compiler, reflected_resources[i].id, SpvDecorationBinding));
-    }
-
     // If source is HLSL, we might have separate images and samplers
     if (num_texture_samplers == 0) {
         result = spvc_resources_get_resource_list_for_type(
@@ -1787,11 +1774,7 @@ SDL_ShaderCross_GraphicsShaderMetadata * SDL_ShaderCross_ReflectGraphicsSPIRV(
             spvc_context_destroy(context);
             return NULL;
         }
-
-        for (size_t i = 0; i < num_separate_samplers; i += 1)
-        {
-            highest_sampler_binding_index = SDL_max(highest_sampler_binding_index, (Sint32) spvc_compiler_get_decoration(compiler, reflected_resources[i].id, SpvDecorationBinding));
-        }
+        num_texture_samplers = num_separate_samplers;
     }
 
     // Storage textures
@@ -1806,11 +1789,6 @@ SDL_ShaderCross_GraphicsShaderMetadata * SDL_ShaderCross_ReflectGraphicsSPIRV(
         return NULL;
     }
 
-    for (size_t i = 0; i < num_storage_buffers; i += 1)
-    {
-        highest_storage_texture_binding_index = SDL_max(highest_storage_texture_binding_index, (Sint32) spvc_compiler_get_decoration(compiler, reflected_resources[i].id, SpvDecorationBinding));
-    }
-
     // If source is HLSL, storage images might be marked as separate images
     result = spvc_resources_get_resource_list_for_type(
         resources,
@@ -1822,11 +1800,8 @@ SDL_ShaderCross_GraphicsShaderMetadata * SDL_ShaderCross_ReflectGraphicsSPIRV(
         spvc_context_destroy(context);
         return NULL;
     }
-
-    for (size_t i = 0; i < num_storage_buffers; i += 1)
-    {
-        highest_storage_texture_binding_index = SDL_max(highest_storage_texture_binding_index, (Sint32) spvc_compiler_get_decoration(compiler, reflected_resources[i].id, SpvDecorationBinding));
-    }
+    // The number of storage textures is the number of separate images minus the number of samplers.
+    num_storage_textures += (num_separate_images - num_separate_samplers);
 
     // Storage buffers
     result = spvc_resources_get_resource_list_for_type(
@@ -1840,11 +1815,6 @@ SDL_ShaderCross_GraphicsShaderMetadata * SDL_ShaderCross_ReflectGraphicsSPIRV(
         return NULL;
     }
 
-    for (size_t i = 0; i < num_storage_buffers; i += 1)
-    {
-        highest_storage_buffer_binding_index = SDL_max(highest_storage_buffer_binding_index, (Sint32) spvc_compiler_get_decoration(compiler, reflected_resources[i].id, SpvDecorationBinding));
-    }
-
     // Uniform buffers
     result = spvc_resources_get_resource_list_for_type(
         resources,
@@ -1855,11 +1825,6 @@ SDL_ShaderCross_GraphicsShaderMetadata * SDL_ShaderCross_ReflectGraphicsSPIRV(
         SPVC_ERROR(spvc_resources_get_resource_list_for_type);
         spvc_context_destroy(context);
         return NULL;
-    }
-
-    for (size_t i = 0; i < num_uniform_buffers; i += 1)
-    {
-        highest_uniform_buffer_binding_index = SDL_max(highest_uniform_buffer_binding_index, (Sint32) spvc_compiler_get_decoration(compiler, reflected_resources[i].id, SpvDecorationBinding));
     }
 
     // Inputs (stage 1: count number of inputs, and name lengths)
@@ -1934,10 +1899,10 @@ SDL_ShaderCross_GraphicsShaderMetadata * SDL_ShaderCross_ReflectGraphicsSPIRV(
     SDL_ShaderCross_INTERNAL_GetIOVars(compiler, reflected_resources, num_outputs, allocMetadata->outputs, allocMemory + offset_outputnames);
     spvc_context_destroy(context);
 
-    allocMetadata->num_samplers = highest_sampler_binding_index + 1;
-    allocMetadata->num_storage_textures = highest_storage_texture_binding_index + 1;
-    allocMetadata->num_storage_buffers = highest_storage_buffer_binding_index + 1;
-    allocMetadata->num_uniform_buffers = highest_uniform_buffer_binding_index + 1;
+    allocMetadata->num_samplers = num_texture_samplers;
+    allocMetadata->num_storage_textures = num_storage_textures;
+    allocMetadata->num_storage_buffers = num_storage_buffers;
+    allocMetadata->num_uniform_buffers = num_uniform_buffers;
     allocMetadata->num_inputs = num_inputs;
     allocMetadata->num_outputs = num_outputs;
 
@@ -1954,20 +1919,16 @@ SDL_ShaderCross_ComputePipelineMetadata * SDL_ShaderCross_ReflectComputeSPIRV(
     spvc_parsed_ir ir = NULL;
     spvc_compiler compiler = NULL;
     size_t num_texture_samplers = 0;
+    size_t num_readonly_storage_textures = 0;
+    size_t num_readonly_storage_buffers = 0;
+    size_t num_readwrite_storage_textures = 0;
+    size_t num_readwrite_storage_buffers = 0;
     size_t num_uniform_buffers = 0;
 
     size_t num_storage_textures = 0;
     size_t num_storage_buffers = 0;
     size_t num_separate_samplers = 0; // HLSL edge case
     size_t num_separate_images = 0; // HLSL edge case
-
-    // The client might have unused resources that get optimized out by the compiler.
-    // We output the resource count as the highest binding index + 1 to avoid bindings becoming out of order.
-    Sint32 highest_sampler_binding_index = -1;
-    Sint32 highest_readonly_storage_texture_binding_index = -1;
-    Sint32 highest_readwrite_storage_texture_binding_index = -1;
-    Sint32 highest_readonly_storage_buffer_binding_index = -1;
-    Sint32 highest_readwrite_storage_buffer_binding_index = -1;
 
     (void) metadataProps;
 
@@ -2021,11 +1982,6 @@ SDL_ShaderCross_ComputePipelineMetadata * SDL_ShaderCross_ReflectComputeSPIRV(
         return false;
     }
 
-    for (size_t i = 0; i < num_texture_samplers; i += 1)
-    {
-        highest_sampler_binding_index = SDL_max(highest_sampler_binding_index, (Sint32) spvc_compiler_get_decoration(compiler, reflected_resources[i].id, SpvDecorationBinding));
-    }
-
     // If source is HLSL, we might have separate images and samplers
     if (num_texture_samplers == 0) {
         result = spvc_resources_get_resource_list_for_type(
@@ -2038,11 +1994,7 @@ SDL_ShaderCross_ComputePipelineMetadata * SDL_ShaderCross_ReflectComputeSPIRV(
             spvc_context_destroy(context);
             return false;
         }
-
-        for (size_t i = 0; i < num_separate_samplers; i += 1)
-        {
-            highest_sampler_binding_index = SDL_max(highest_sampler_binding_index, (Sint32) spvc_compiler_get_decoration(compiler, reflected_resources[i].id, SpvDecorationBinding));
-        }
+        num_texture_samplers = num_separate_samplers;
     }
 
     // Storage textures
@@ -2067,16 +2019,14 @@ SDL_ShaderCross_ComputePipelineMetadata * SDL_ShaderCross_ReflectComputeSPIRV(
         unsigned int descriptor_set_index = spvc_compiler_get_decoration(compiler, reflected_resources[i].id, SpvDecorationDescriptorSet);
 
         if (descriptor_set_index == 0) {
-            highest_readonly_storage_texture_binding_index = SDL_max(highest_readonly_storage_texture_binding_index, (Sint32) spvc_compiler_get_decoration(compiler, reflected_resources[i].id, SpvDecorationBinding));
-
+            num_readonly_storage_textures += 1;
         } else if (descriptor_set_index == 1) {
-            highest_readwrite_storage_texture_binding_index = SDL_max(highest_readwrite_storage_texture_binding_index, (Sint32) spvc_compiler_get_decoration(compiler, reflected_resources[i].id, SpvDecorationBinding));
+            num_readwrite_storage_textures += 1;
         } else {
             SDL_SetError("%s", "Descriptor set index for compute storage texture must be 0 or 1!");
             spvc_context_destroy(context);
             return false;
         }
-
     }
 
     // If source is HLSL, readonly storage images might be marked as separate images
@@ -2091,6 +2041,9 @@ SDL_ShaderCross_ComputePipelineMetadata * SDL_ShaderCross_ReflectComputeSPIRV(
         return false;
     }
 
+    // The number of storage textures is the number of separate images minus the number of samplers.
+    num_storage_textures += (num_separate_images - num_separate_samplers);
+
     for (size_t i = num_separate_samplers; i < num_separate_images; i += 1) {
         if (!spvc_compiler_has_decoration(compiler, reflected_resources[i].id, SpvDecorationDescriptorSet) || !spvc_compiler_has_decoration(compiler, reflected_resources[i].id, SpvDecorationBinding)) {
             SDL_SetError("%s", "Shader resources must have descriptor set and binding index!");
@@ -2101,15 +2054,14 @@ SDL_ShaderCross_ComputePipelineMetadata * SDL_ShaderCross_ReflectComputeSPIRV(
         unsigned int descriptor_set_index = spvc_compiler_get_decoration(compiler, reflected_resources[i].id, SpvDecorationDescriptorSet);
 
         if (descriptor_set_index == 0) {
-            highest_readonly_storage_texture_binding_index = SDL_max(highest_readonly_storage_texture_binding_index, (Sint32) spvc_compiler_get_decoration(compiler, reflected_resources[i].id, SpvDecorationBinding));
+            num_readonly_storage_textures += 1;
         } else if (descriptor_set_index == 1) {
-            highest_readwrite_storage_texture_binding_index = SDL_max(highest_readwrite_storage_texture_binding_index, (Sint32) spvc_compiler_get_decoration(compiler, reflected_resources[i].id, SpvDecorationBinding));
+            num_readwrite_storage_textures += 1;
         } else {
             SDL_SetError("%s", "Descriptor set index for compute storage texture must be 0 or 1!");
             spvc_context_destroy(context);
             return false;
         }
-
     }
 
     // Storage buffers
@@ -2140,9 +2092,9 @@ SDL_ShaderCross_ComputePipelineMetadata * SDL_ShaderCross_ReflectComputeSPIRV(
         }
 
         if (descriptor_set_index == 0) {
-            highest_readonly_storage_buffer_binding_index = SDL_max(highest_readonly_storage_buffer_binding_index, (Sint32) spvc_compiler_get_decoration(compiler, reflected_resources[i].id, SpvDecorationBinding));
+            num_readonly_storage_buffers += 1;
         } else if (descriptor_set_index == 1) {
-            highest_readwrite_storage_buffer_binding_index = SDL_max(highest_readwrite_storage_buffer_binding_index, (Sint32) spvc_compiler_get_decoration(compiler, reflected_resources[i].id, SpvDecorationBinding));
+            num_readwrite_storage_buffers += 1;
         } else {
             SDL_SetError("%s", "Descriptor set index for compute storage buffer must be 0 or 1!");
             spvc_context_destroy(context);
@@ -2162,12 +2114,6 @@ SDL_ShaderCross_ComputePipelineMetadata * SDL_ShaderCross_ReflectComputeSPIRV(
         return false;
     }
 
-    Sint32 highest_uniform_buffer_binding_index = -1;
-    for (size_t i = 0; i < num_uniform_buffers; i += 1)
-    {
-        highest_uniform_buffer_binding_index = SDL_max(highest_uniform_buffer_binding_index, (Sint32) spvc_compiler_get_decoration(compiler, reflected_resources[i].id, SpvDecorationBinding));
-    }
-
     // Threadcount
     SDL_ShaderCross_ComputePipelineMetadata *metadata = SDL_malloc(sizeof(SDL_ShaderCross_ComputePipelineMetadata));
     if (!metadata) {
@@ -2179,12 +2125,12 @@ SDL_ShaderCross_ComputePipelineMetadata * SDL_ShaderCross_ReflectComputeSPIRV(
 
     spvc_context_destroy(context);
 
-    metadata->num_samplers = highest_sampler_binding_index + 1;
-    metadata->num_readonly_storage_textures = highest_readonly_storage_texture_binding_index + 1;
-    metadata->num_readonly_storage_buffers = highest_readonly_storage_buffer_binding_index + 1;
-    metadata->num_readwrite_storage_textures = highest_readwrite_storage_texture_binding_index + 1;
-    metadata->num_readwrite_storage_buffers = highest_readwrite_storage_buffer_binding_index + 1;
-    metadata->num_uniform_buffers = highest_uniform_buffer_binding_index + 1;
+    metadata->num_samplers = num_texture_samplers;
+    metadata->num_readonly_storage_textures = num_readonly_storage_textures;
+    metadata->num_readonly_storage_buffers = num_readonly_storage_buffers;
+    metadata->num_readwrite_storage_textures = num_readwrite_storage_textures;
+    metadata->num_readwrite_storage_buffers = num_readwrite_storage_buffers;
+    metadata->num_uniform_buffers = num_uniform_buffers;
     return metadata;
 }
 


### PR DESCRIPTION
This reverts the resource counting rework and adds the `-fspv-preserve-bindings` and `-fspv-preserve-interface` flags to the DXC compile call. There is actually not enough information to correctly infer resource counts from register bindings (except for uniform buffers which are in their own register space) so I think our policy for clients should be to declare all resources in consecutive register spaces even if they aren't being used.

Unfortunately there seems to be a bug with actually using the preserve interface flag from dxcompiler.dll, so we'll need to figure that out: https://github.com/microsoft/DirectXShaderCompiler/issues/7631

Something I'm not sure about: should preservation be the default, or should it be opted in via a flag? The main argument in favor of it being default is that having unused resources go missing is surprising behavior and changes the result of reflection.

Resolves https://github.com/libsdl-org/SDL_shadercross/issues/127