### PR TITLE
Don't trigger `find_package` when user builds a shared-lib version of SDL3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,7 +22,7 @@ include("${CMAKE_CURRENT_LIST_DIR}/cmake/sdlcpu.cmake")
 include("${CMAKE_CURRENT_LIST_DIR}/cmake/sdlplatform.cmake")
 include("${CMAKE_CURRENT_LIST_DIR}/cmake/sdlmanpages.cmake")
 
-if(NOT TARGET SDL3::SDL3-static)
+if(NOT TARGET SDL3::SDL3-static AND NOT TARGET SDL3::SDL3)
     find_package(SDL3 ${SDL_REQUIRED_VERSION})
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,16 +22,21 @@ include("${CMAKE_CURRENT_LIST_DIR}/cmake/sdlcpu.cmake")
 include("${CMAKE_CURRENT_LIST_DIR}/cmake/sdlplatform.cmake")
 include("${CMAKE_CURRENT_LIST_DIR}/cmake/sdlmanpages.cmake")
 
-if(NOT TARGET SDL3::SDL3-static AND NOT TARGET SDL3::SDL3)
-    find_package(SDL3 ${SDL_REQUIRED_VERSION})
-endif()
-
 if(BUILD_SHARED_LIBS)
 	set(SDLSHADERCROSS_SHARED_DEFAULT ON)
 	set(SDLSHADERCROSS_STATIC_DEFAULT OFF)
+
+	set(sdl3_target_name SDL3::SDL3-shared)
+    list(APPEND sdl_required_components SDL3-shared)
 else()
 	set(SDLSHADERCROSS_SHARED_DEFAULT OFF)
 	set(SDLSHADERCROSS_STATIC_DEFAULT ON)
+
+	set(sdl3_target_name SDL3::SDL3)
+endif()
+
+if(NOT TARGET SDL3::Headers OR NOT TARGET ${sdl3_target_name})
+    find_package(SDL3 ${SDL_REQUIRED_VERSION} REQUIRED COMPONENTS ${sdl_required_components})
 endif()
 
 # Options

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,18 +25,9 @@ include("${CMAKE_CURRENT_LIST_DIR}/cmake/sdlmanpages.cmake")
 if(BUILD_SHARED_LIBS)
 	set(SDLSHADERCROSS_SHARED_DEFAULT ON)
 	set(SDLSHADERCROSS_STATIC_DEFAULT OFF)
-
-	set(sdl3_target_name SDL3::SDL3-shared)
-    list(APPEND sdl_required_components SDL3-shared)
 else()
 	set(SDLSHADERCROSS_SHARED_DEFAULT OFF)
 	set(SDLSHADERCROSS_STATIC_DEFAULT ON)
-
-	set(sdl3_target_name SDL3::SDL3)
-endif()
-
-if(NOT TARGET SDL3::Headers OR NOT TARGET ${sdl3_target_name})
-    find_package(SDL3 ${SDL_REQUIRED_VERSION} REQUIRED COMPONENTS ${sdl_required_components})
 endif()
 
 # Options
@@ -56,6 +47,10 @@ cmake_dependent_option(SDLSHADERCROSS_INSTALL_RUNTIME "Download, build and insta
 
 option(SDLSHADERCROSS_TESTS "Build unit tests?" OFF)
 cmake_dependent_option(SDLSHADERCROSS_TESTS_TRACKMEM "Enable memory tracking in tests" OFF SDLSHADERCROSS_TESTS OFF)
+
+if((SDLSHADERCROSS_STATIC AND NOT TARGET SDL3::SDL3) OR (SDLSHADERCROSS_SHARED AND NOT TARGET SDL3::SDL3-shared))
+    find_package(SDL3 ${SDL_REQUIRED_VERSION} REQUIRED)
+endif()
 
 sdl_calculate_derived_version_variables(${MAJOR_VERSION} ${MINOR_VERSION} ${MICRO_VERSION})
 SDL_DetectTargetCPUArchitectures(SDL_CPU_NAMES)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,10 +30,17 @@ else()
 	set(SDLSHADERCROSS_STATIC_DEFAULT ON)
 endif()
 
-# Options
-option(SDLSHADERCROSS_DXC "Enable HLSL compilation via DXC" ON)
+# Configure shared/static options first
 option(SDLSHADERCROSS_SHARED "Build shared SDL_shadercross library" ${SDLSHADERCROSS_SHARED_DEFAULT})
 option(SDLSHADERCROSS_STATIC "Build static SDL_shadercross library" ${SDLSHADERCROSS_STATIC_DEFAULT})
+
+# Find SDL3 (if not already available)
+if((SDLSHADERCROSS_STATIC AND NOT TARGET SDL3::SDL3) OR (SDLSHADERCROSS_SHARED AND NOT TARGET SDL3::SDL3-shared))
+    find_package(SDL3 ${SDL_REQUIRED_VERSION} REQUIRED)
+endif()
+
+# Configure remaining shadercross options
+option(SDLSHADERCROSS_DXC "Enable HLSL compilation via DXC" ON)
 option(SDLSHADERCROSS_SPIRVCROSS_SHARED "Link to shared library variants of dependencies" ON)
 option(SDLSHADERCROSS_VENDORED "Use vendored dependencies" OFF)
 option(SDLSHADERCROSS_CLI "Build command line executable" ON)
@@ -47,10 +54,6 @@ cmake_dependent_option(SDLSHADERCROSS_INSTALL_RUNTIME "Download, build and insta
 
 option(SDLSHADERCROSS_TESTS "Build unit tests?" OFF)
 cmake_dependent_option(SDLSHADERCROSS_TESTS_TRACKMEM "Enable memory tracking in tests" OFF SDLSHADERCROSS_TESTS OFF)
-
-if((SDLSHADERCROSS_STATIC AND NOT TARGET SDL3::SDL3) OR (SDLSHADERCROSS_SHARED AND NOT TARGET SDL3::SDL3-shared))
-    find_package(SDL3 ${SDL_REQUIRED_VERSION} REQUIRED)
-endif()
 
 sdl_calculate_derived_version_variables(${MAJOR_VERSION} ${MINOR_VERSION} ${MICRO_VERSION})
 SDL_DetectTargetCPUArchitectures(SDL_CPU_NAMES)


### PR DESCRIPTION
Currently when user builds SDL_shadercross along with a shared-library version of SDL3, the check `if(NOT TARGET SDL3::SDL3-static)` in `CMakeLists.txt` won't block the package search with `find_package` because it only verifies if the target of a static version of SDL3 library is present. If user doesn't have SDL3 installed in the system, the build will fail resulting with:

```
CMake Warning at external/SDL_shadercross/CMakeLists.txt:26 (find_package):
  By not providing "FindSDL3.cmake" in CMAKE_MODULE_PATH this project has
  asked CMake to find a package configuration file provided by "SDL3", but
  CMake did not find one.

  Could not find a package configuration file provided by "SDL3" (requested
  version 3.1.3) with any of the following names:

    SDL3Config.cmake
    sdl3-config.cmake

  Add the installation prefix of "SDL3" to CMAKE_PREFIX_PATH or set
  "SDL3_DIR" to a directory containing one of the above files.  If "SDL3"
  provides a separate development package or SDK, be sure it has been
  installed.
```

This PR extends the check to also cover for the SDL3 shared library case.