### PR TITLE
Refactor reflection API

### DIFF
--- a/include/SDL3_shadercross/SDL_shadercross.h
+++ b/include/SDL3_shadercross/SDL_shadercross.h
@@ -67,17 +67,21 @@ typedef struct SDL_ShaderCross_IOVarMetadata {
     Uint32 vector_size;                     /**< The number of components in the vector type of the variable. */
 } SDL_ShaderCross_IOVarMetadata;
 
-typedef struct SDL_ShaderCross_GraphicsShaderMetadata
+typedef struct SDL_ShaderCross_GraphicsShaderResourceInfo
 {
     Uint32 num_samplers;                     /**< The number of samplers defined in the shader. */
     Uint32 num_storage_textures;             /**< The number of storage textures defined in the shader. */
     Uint32 num_storage_buffers;              /**< The number of storage buffers defined in the shader. */
     Uint32 num_uniform_buffers;              /**< The number of uniform buffers defined in the shader. */
+} SDL_ShaderCross_GraphicsShaderResourceInfo;
+
+typedef struct SDL_ShaderCross_GraphicsShaderIOInfo
+{
     Uint32 num_inputs;                       /**< The number of inputs defined in the shader. */
     SDL_ShaderCross_IOVarMetadata *inputs;   /**< The inputs defined in the shader. */
     Uint32 num_outputs;                      /**< The number of outputs defined in the shader. */
     SDL_ShaderCross_IOVarMetadata *outputs;  /**< The outputs defined in the shader. */
-} SDL_ShaderCross_GraphicsShaderMetadata;
+} SDL_ShaderCross_GraphicsShaderIOInfo;
 
 typedef struct SDL_ShaderCross_ComputePipelineMetadata
 {
@@ -201,7 +205,7 @@ extern SDL_DECLSPEC void * SDLCALL SDL_ShaderCross_CompileDXILFromSPIRV(
  *
  * \param device the SDL GPU device.
  * \param info a struct describing the shader to transpile.
- * \param metadata a struct describing shader metadata. Can be obtained from SDL_ShaderCross_ReflectGraphicsSPIRV().
+ * \param metadata a struct describing shader metadata. Can be obtained from SDL_ShaderCross_ReflectSPIRVGraphicsResources().
  * \param props a properties object filled in with extra shader metadata.
  * \returns a compiled SDL_GPUShader.
  *
@@ -210,7 +214,7 @@ extern SDL_DECLSPEC void * SDLCALL SDL_ShaderCross_CompileDXILFromSPIRV(
 extern SDL_DECLSPEC SDL_GPUShader * SDLCALL SDL_ShaderCross_CompileGraphicsShaderFromSPIRV(
     SDL_GPUDevice *device,
     const SDL_ShaderCross_SPIRV_Info *info,
-    const SDL_ShaderCross_GraphicsShaderMetadata *metadata,
+    const SDL_ShaderCross_GraphicsShaderResourceInfo *metadata,
     SDL_PropertiesID props);
 
 /**
@@ -218,7 +222,7 @@ extern SDL_DECLSPEC SDL_GPUShader * SDLCALL SDL_ShaderCross_CompileGraphicsShade
  *
  * \param device the SDL GPU device.
  * \param info a struct describing the shader to transpile.
- * \param metadata a struct describing shader metadata. Can be obtained from SDL_ShaderCross_ReflectComputeSPIRV().
+ * \param metadata a struct describing shader metadata. Can be obtained from SDL_ShaderCross_ReflectSPIRVCompute().
  * \param props a properties object filled in with extra shader metadata.
  * \returns a compiled SDL_GPUComputePipeline.
  *
@@ -240,7 +244,22 @@ extern SDL_DECLSPEC SDL_GPUComputePipeline * SDLCALL SDL_ShaderCross_CompileComp
  *
  * \threadsafety It is safe to call this function from any thread.
  */
-extern SDL_DECLSPEC SDL_ShaderCross_GraphicsShaderMetadata * SDLCALL SDL_ShaderCross_ReflectGraphicsSPIRV(
+extern SDL_DECLSPEC SDL_ShaderCross_GraphicsShaderResourceInfo * SDLCALL SDL_ShaderCross_ReflectSPIRVGraphicsResources(
+    const Uint8 *bytecode,
+    size_t bytecode_size,
+    SDL_PropertiesID props);
+
+/**
+ * Reflect graphics shader IO from SPIRV code. If your shader source is HLSL, you should obtain SPIR-V bytecode from SDL_ShaderCross_CompileSPIRVFromHLSL(). This must be freed with SDL_free() when you are done with the metadata.
+ *
+ * \param bytecode the SPIRV bytecode.
+ * \param bytecode_size the length of the SPIRV bytecode.
+ * \param props a properties object filled in with extra shader metadata, provided by the user.
+ * \returns A metadata struct on success, NULL otherwise. The struct must be free'd when it is no longer needed.
+ *
+ * \threadsafety It is safe ot call this function from any thread.
+ */
+extern SDL_DECLSPEC SDL_ShaderCross_GraphicsShaderIOInfo * SDLCALL SDL_ShaderCross_ReflectSPIRVGraphicsIO(
     const Uint8 *bytecode,
     size_t bytecode_size,
     SDL_PropertiesID props);
@@ -255,7 +274,7 @@ extern SDL_DECLSPEC SDL_ShaderCross_GraphicsShaderMetadata * SDLCALL SDL_ShaderC
  *
  * \threadsafety It is safe to call this function from any thread.
  */
-extern SDL_DECLSPEC SDL_ShaderCross_ComputePipelineMetadata * SDLCALL SDL_ShaderCross_ReflectComputeSPIRV(
+extern SDL_DECLSPEC SDL_ShaderCross_ComputePipelineMetadata * SDLCALL SDL_ShaderCross_ReflectSPIRVCompute(
     const Uint8 *bytecode,
     size_t bytecode_size,
     SDL_PropertiesID props);

--- a/src/SDL_shadercross.sym
+++ b/src/SDL_shadercross.sym
@@ -13,7 +13,8 @@ SDL3_shadercross_0.0.0 {
     SDL_ShaderCross_CompileDXBCFromHLSL;
     SDL_ShaderCross_CompileDXILFromHLSL;
     SDL_ShaderCross_CompileSPIRVFromHLSL;
-    SDL_ShaderCross_ReflectGraphicsSPIRV;
-    SDL_ShaderCross_ReflectComputeSPIRV;
+    SDL_ShaderCross_ReflectSPIRVGraphicsResources;
+    SDL_ShaderCross_ReflectSPIRVGraphicsIO
+    SDL_ShaderCross_ReflectSPIRVCompute;
   local: *;
 };

--- a/src/SDL_shadercross.sym
+++ b/src/SDL_shadercross.sym
@@ -14,7 +14,7 @@ SDL3_shadercross_0.0.0 {
     SDL_ShaderCross_CompileDXILFromHLSL;
     SDL_ShaderCross_CompileSPIRVFromHLSL;
     SDL_ShaderCross_ReflectSPIRVGraphicsResources;
-    SDL_ShaderCross_ReflectSPIRVGraphicsIO
+    SDL_ShaderCross_ReflectSPIRVGraphicsIO;
     SDL_ShaderCross_ReflectSPIRVCompute;
   local: *;
 };

--- a/test/main.c
+++ b/test/main.c
@@ -269,7 +269,8 @@ static int SDLCALL shadercross_ReflectSPIRV(void *args)
     Uint32 i;
     void *spirv_shader;
     size_t spirv_shader_size;
-    SDL_ShaderCross_GraphicsShaderMetadata *shader_gfx_metadata;
+    SDL_ShaderCross_GraphicsShaderResourceInfo *shader_gfx_resource_info;
+    SDL_ShaderCross_GraphicsShaderIOInfo *shader_gfx_io_info;
 
     (void)args;
     if (!(SDL_ShaderCross_GetSPIRVShaderFormats() & SDL_GPU_SHADERFORMAT_MSL)) {
@@ -299,25 +300,28 @@ static int SDLCALL shadercross_ReflectSPIRV(void *args)
 
     SDLTest_AssertPass("Reflect SPIRV");
 
-    shader_gfx_metadata = SDL_ShaderCross_ReflectGraphicsSPIRV(spirv_shader, spirv_shader_size, 0);
-    SDLTest_AssertCheck(shader_gfx_metadata != NULL, "SDL_ShaderCross_ReflectGraphicsSPIRV returns non-NULL shader (%s)", SDL_GetError());
-    SDLTest_AssertCheck(shader_gfx_metadata->num_samplers == 0, "num_samplers is %d, should be 0", shader_gfx_metadata->num_samplers);
-    SDLTest_AssertCheck(shader_gfx_metadata->num_storage_textures == 0, "num_storage_textures is %d, should be 0", shader_gfx_metadata->num_storage_textures);
-    SDLTest_AssertCheck(shader_gfx_metadata->num_storage_buffers == 0, "num_storage_buffers is %d, should be 0", shader_gfx_metadata->num_storage_buffers);
-    SDLTest_AssertCheck(shader_gfx_metadata->num_uniform_buffers == 1, "num_uniform_buffers is %d, should be 1", shader_gfx_metadata->num_uniform_buffers);
-    SDLTest_AssertCheck(shader_gfx_metadata->num_inputs == 1, "num_inputs is %d, should be 1", shader_gfx_metadata->num_inputs);
-    SDLTest_AssertCheck(shader_gfx_metadata->num_outputs == 1, "num_outputs is %d, should be 1", shader_gfx_metadata->num_outputs);
+    shader_gfx_resource_info = SDL_ShaderCross_ReflectSPIRVGraphicsResources(spirv_shader, spirv_shader_size, 0);
+    shader_gfx_io_info = SDL_ShaderCross_ReflectSPIRVGraphicsIO(spirv_shader, spirv_shader_size, 0);
+    SDLTest_AssertCheck(shader_gfx_resource_info != NULL, "SDL_ShaderCross_ReflectSPIRVGraphicsResources returns non-NULL shader (%s)", SDL_GetError());
+    SDLTest_AssertCheck(shader_gfx_io_info != NULL, "SDL_ShaderCross_ReflectSPIRVGraphicsIO returns non-NULL shader (%s)", SDL_GetError());
+    SDLTest_AssertCheck(shader_gfx_resource_info->num_samplers == 0, "num_samplers is %d, should be 0", shader_gfx_resource_info->num_samplers);
+    SDLTest_AssertCheck(shader_gfx_resource_info->num_storage_textures == 0, "num_storage_textures is %d, should be 0", shader_gfx_resource_info->num_storage_textures);
+    SDLTest_AssertCheck(shader_gfx_resource_info->num_storage_buffers == 0, "num_storage_buffers is %d, should be 0", shader_gfx_resource_info->num_storage_buffers);
+    SDLTest_AssertCheck(shader_gfx_resource_info->num_uniform_buffers == 1, "num_uniform_buffers is %d, should be 1", shader_gfx_resource_info->num_uniform_buffers);
+    SDLTest_AssertCheck(shader_gfx_io_info->num_inputs == 1, "num_inputs is %d, should be 1", shader_gfx_io_info->num_inputs);
+    SDLTest_AssertCheck(shader_gfx_io_info->num_outputs == 1, "num_outputs is %d, should be 1", shader_gfx_io_info->num_outputs);
 
     SDLTest_AssertPass("inputs:");
-    for (i = 0; i < shader_gfx_metadata->num_inputs; i++) {
-        log_SDL_ShaderCross_IOVarMetadata(i, &shader_gfx_metadata->inputs[i]);
+    for (i = 0; i < shader_gfx_io_info->num_inputs; i++) {
+        log_SDL_ShaderCross_IOVarMetadata(i, &shader_gfx_io_info->inputs[i]);
     }
     SDLTest_AssertPass("outputs:");
-    for (i = 0; i < shader_gfx_metadata->num_outputs; i++) {
-        log_SDL_ShaderCross_IOVarMetadata(i, &shader_gfx_metadata->outputs[i]);
+    for (i = 0; i < shader_gfx_io_info->num_outputs; i++) {
+        log_SDL_ShaderCross_IOVarMetadata(i, &shader_gfx_io_info->outputs[i]);
     }
 
-    SDL_free(shader_gfx_metadata);
+    SDL_free(shader_gfx_resource_info);
+    SDL_free(shader_gfx_io_info);
 
     SDL_free(spirv_shader);
     return TEST_COMPLETED;


### PR DESCRIPTION
From #173 

> [SDL_ShaderCross_CompileGraphicsShaderFromSPIRV](https://github.com/libsdl-org/SDL_shadercross/blob/4ce748310f57d405b4eb2a79fbbc7e974d6491ec/include/SDL3_shadercross/SDL_shadercross.h#L211-L215) accepts a const SDL_ShaderCross_ComputePipelineMetadata *metadata argument. But [this type](https://github.com/libsdl-org/SDL_shadercross/blob/4ce748310f57d405b4eb2a79fbbc7e974d6491ec/include/SDL3_shadercross/SDL_shadercross.h#L70-L80) has also irrelevant members: you don't need the inputs and outputs to compile a shader.

> Is this ok (and maybe should be documented)? Or should we introduce a new type?

I agree that this is awkward. I've separated the types and functions. Now we have...

Types:
- `SDL_ShaderCross_GraphicsShaderResourceInfo`
- `SDL_ShaderCross_GraphicsShaderIOInfo`
- `SDL_ShaderCross_ComputePipelineMetadata`

Functions: 
- `SDL_ShaderCross_ReflectSPIRVGraphicsResources`
- `SDL_ShaderCross_ReflectSPIRVGraphicsIO`
- `SDL_ShaderCross_ReflectSPIRVCompute`

I thought about combining `SDL_ShaderCross_ReflectSPIRVGraphicsResources` and `SDL_ShaderCross_ReflectSPIRVGraphicsIO` into a single function, but it got too weird with the relatively complex allocation that has to be performed for the IO reflection.
