### PR TITLE
Remove unnecessary input from CompileGraphicsShaderFromSPIRV

### DIFF
--- a/include/SDL3_shadercross/SDL_shadercross.h
+++ b/include/SDL3_shadercross/SDL_shadercross.h
@@ -206,7 +206,7 @@ extern SDL_DECLSPEC void * SDLCALL SDL_ShaderCross_CompileDXILFromSPIRV(
  *
  * \param device the SDL GPU device.
  * \param info a struct describing the shader to transpile.
- * \param metadata a struct describing resource info of the shader. Can be obtained from SDL_ShaderCross_ReflectGraphicsSPIRV().
+ * \param resource_info a struct describing resource info of the shader. Can be obtained from SDL_ShaderCross_ReflectGraphicsSPIRV().
  * \param props a properties object filled in with extra shader metadata.
  * \returns a compiled SDL_GPUShader.
  *

--- a/include/SDL3_shadercross/SDL_shadercross.h
+++ b/include/SDL3_shadercross/SDL_shadercross.h
@@ -67,12 +67,17 @@ typedef struct SDL_ShaderCross_IOVarMetadata {
     Uint32 vector_size;                     /**< The number of components in the vector type of the variable. */
 } SDL_ShaderCross_IOVarMetadata;
 
-typedef struct SDL_ShaderCross_GraphicsShaderMetadata
+typedef struct SDL_ShaderCross_GraphicsShaderResourceInfo
 {
     Uint32 num_samplers;                     /**< The number of samplers defined in the shader. */
     Uint32 num_storage_textures;             /**< The number of storage textures defined in the shader. */
     Uint32 num_storage_buffers;              /**< The number of storage buffers defined in the shader. */
     Uint32 num_uniform_buffers;              /**< The number of uniform buffers defined in the shader. */
+} SDL_ShaderCross_GraphicsShaderResourceInfo;
+
+typedef struct SDL_ShaderCross_GraphicsShaderMetadata
+{
+    SDL_ShaderCross_GraphicsShaderResourceInfo resource_info; /**< Sub-struct containing the resource info of the shader. */
     Uint32 num_inputs;                       /**< The number of inputs defined in the shader. */
     SDL_ShaderCross_IOVarMetadata *inputs;   /**< The inputs defined in the shader. */
     Uint32 num_outputs;                      /**< The number of outputs defined in the shader. */
@@ -201,7 +206,7 @@ extern SDL_DECLSPEC void * SDLCALL SDL_ShaderCross_CompileDXILFromSPIRV(
  *
  * \param device the SDL GPU device.
  * \param info a struct describing the shader to transpile.
- * \param metadata a struct describing shader metadata. Can be obtained from SDL_ShaderCross_ReflectGraphicsSPIRV().
+ * \param metadata a struct describing resource info of the shader. Can be obtained from SDL_ShaderCross_ReflectGraphicsSPIRV().
  * \param props a properties object filled in with extra shader metadata.
  * \returns a compiled SDL_GPUShader.
  *
@@ -210,7 +215,7 @@ extern SDL_DECLSPEC void * SDLCALL SDL_ShaderCross_CompileDXILFromSPIRV(
 extern SDL_DECLSPEC SDL_GPUShader * SDLCALL SDL_ShaderCross_CompileGraphicsShaderFromSPIRV(
     SDL_GPUDevice *device,
     const SDL_ShaderCross_SPIRV_Info *info,
-    const SDL_ShaderCross_GraphicsShaderMetadata *metadata,
+    const SDL_ShaderCross_GraphicsShaderResourceInfo *resource_info,
     SDL_PropertiesID props);
 
 /**

--- a/src/SDL_shadercross.c
+++ b/src/SDL_shadercross.c
@@ -1905,10 +1905,10 @@ SDL_ShaderCross_GraphicsShaderMetadata * SDL_ShaderCross_ReflectGraphicsSPIRV(
     SDL_ShaderCross_INTERNAL_GetIOVars(compiler, reflected_resources, num_outputs, allocMetadata->outputs, allocMemory + offset_outputnames);
     spvc_context_destroy(context);
 
-    allocMetadata->num_samplers = num_texture_samplers;
-    allocMetadata->num_storage_textures = num_storage_textures;
-    allocMetadata->num_storage_buffers = num_storage_buffers;
-    allocMetadata->num_uniform_buffers = num_uniform_buffers;
+    allocMetadata->resource_info.num_samplers = num_texture_samplers;
+    allocMetadata->resource_info.num_storage_textures = num_storage_textures;
+    allocMetadata->resource_info.num_storage_buffers = num_storage_buffers;
+    allocMetadata->resource_info.num_uniform_buffers = num_uniform_buffers;
     allocMetadata->num_inputs = num_inputs;
     allocMetadata->num_outputs = num_outputs;
 
@@ -2247,10 +2247,10 @@ static void *SDL_ShaderCross_INTERNAL_CompileFromSPIRV(
         createInfo.entrypoint = transpileContext->cleansed_entrypoint;
         createInfo.format = targetFormat;
         createInfo.stage = (SDL_GPUShaderStage)info->shader_stage;
-        createInfo.num_samplers = shaderInfo->num_samplers;
-        createInfo.num_storage_textures = shaderInfo->num_storage_textures;
-        createInfo.num_storage_buffers = shaderInfo->num_storage_buffers;
-        createInfo.num_uniform_buffers = shaderInfo->num_uniform_buffers;
+        createInfo.num_samplers = shaderInfo->resource_info.num_samplers;
+        createInfo.num_storage_textures = shaderInfo->resource_info.num_storage_textures;
+        createInfo.num_storage_buffers = shaderInfo->resource_info.num_storage_buffers;
+        createInfo.num_uniform_buffers = shaderInfo->resource_info.num_uniform_buffers;
 
         createInfo.props = 0;
 
@@ -2482,17 +2482,17 @@ static void *SDL_ShaderCross_INTERNAL_CreateShaderFromSPIRV(
             return result;
         } else {
             SDL_GPUShaderCreateInfo createInfo;
-            SDL_ShaderCross_GraphicsShaderMetadata *shaderMetadata = (SDL_ShaderCross_GraphicsShaderMetadata *)metadata;
+            SDL_ShaderCross_GraphicsShaderResourceInfo *resourceInfo = (SDL_ShaderCross_GraphicsShaderResourceInfo *)metadata;
 
             createInfo.code = info->bytecode;
             createInfo.code_size = info->bytecode_size;
             createInfo.entrypoint = info->entrypoint;
             createInfo.format = SDL_GPU_SHADERFORMAT_SPIRV;
             createInfo.stage = (SDL_GPUShaderStage)info->shader_stage;
-            createInfo.num_samplers = shaderMetadata->num_samplers;
-            createInfo.num_storage_textures = shaderMetadata->num_storage_textures;
-            createInfo.num_storage_buffers = shaderMetadata->num_storage_buffers;
-            createInfo.num_uniform_buffers = shaderMetadata->num_uniform_buffers;
+            createInfo.num_samplers = resourceInfo->num_samplers;
+            createInfo.num_storage_textures = resourceInfo->num_storage_textures;
+            createInfo.num_storage_buffers = resourceInfo->num_storage_buffers;
+            createInfo.num_uniform_buffers = resourceInfo->num_uniform_buffers;
 
             createInfo.props = 0;
 
@@ -2537,7 +2537,7 @@ static void *SDL_ShaderCross_INTERNAL_CreateShaderFromSPIRV(
 SDL_GPUShader *SDL_ShaderCross_CompileGraphicsShaderFromSPIRV(
     SDL_GPUDevice *device,
     const SDL_ShaderCross_SPIRV_Info *info,
-    const SDL_ShaderCross_GraphicsShaderMetadata *metadata,
+    const SDL_ShaderCross_GraphicsShaderResourceInfo *resourceInfo,
     SDL_PropertiesID props)
 {
     if (device == NULL) {
@@ -2550,7 +2550,7 @@ SDL_GPUShader *SDL_ShaderCross_CompileGraphicsShaderFromSPIRV(
         return NULL;
     }
 
-    if (metadata == NULL) {
+    if (resourceInfo == NULL) {
         SDL_InvalidParamError("metadata");
         return NULL;
     }
@@ -2558,7 +2558,7 @@ SDL_GPUShader *SDL_ShaderCross_CompileGraphicsShaderFromSPIRV(
     return (SDL_GPUShader *)SDL_ShaderCross_INTERNAL_CreateShaderFromSPIRV(
         device,
         info,
-        (void*) metadata,
+        (void*) resourceInfo,
         props);
 }
 

--- a/src/cli.c
+++ b/src/cli.c
@@ -173,10 +173,10 @@ void write_graphics_reflect_json(SDL_IOStream *outputIO, SDL_ShaderCross_Graphic
     SDL_IOprintf(
         outputIO,
         "{ \"samplers\": %u, \"storage_textures\": %u, \"storage_buffers\": %u, \"uniform_buffers\": %u, ",
-        info->num_samplers,
-        info->num_storage_textures,
-        info->num_storage_buffers,
-        info->num_uniform_buffers
+        info->resource_info.num_samplers,
+        info->resource_info.num_storage_textures,
+        info->resource_info.num_storage_buffers,
+        info->resource_info.num_uniform_buffers
     );
 
     SDL_IOprintf(outputIO, "\"inputs\": [");

--- a/test/main.c
+++ b/test/main.c
@@ -301,10 +301,10 @@ static int SDLCALL shadercross_ReflectSPIRV(void *args)
 
     shader_gfx_metadata = SDL_ShaderCross_ReflectGraphicsSPIRV(spirv_shader, spirv_shader_size, 0);
     SDLTest_AssertCheck(shader_gfx_metadata != NULL, "SDL_ShaderCross_ReflectGraphicsSPIRV returns non-NULL shader (%s)", SDL_GetError());
-    SDLTest_AssertCheck(shader_gfx_metadata->num_samplers == 0, "num_samplers is %d, should be 0", shader_gfx_metadata->num_samplers);
-    SDLTest_AssertCheck(shader_gfx_metadata->num_storage_textures == 0, "num_storage_textures is %d, should be 0", shader_gfx_metadata->num_storage_textures);
-    SDLTest_AssertCheck(shader_gfx_metadata->num_storage_buffers == 0, "num_storage_buffers is %d, should be 0", shader_gfx_metadata->num_storage_buffers);
-    SDLTest_AssertCheck(shader_gfx_metadata->num_uniform_buffers == 1, "num_uniform_buffers is %d, should be 1", shader_gfx_metadata->num_uniform_buffers);
+    SDLTest_AssertCheck(shader_gfx_metadata->resource_info.num_samplers == 0, "num_samplers is %d, should be 0", shader_gfx_metadata->resource_info.num_samplers);
+    SDLTest_AssertCheck(shader_gfx_metadata->resource_info.num_storage_textures == 0, "num_storage_textures is %d, should be 0", shader_gfx_metadata->resource_info.num_storage_textures);
+    SDLTest_AssertCheck(shader_gfx_metadata->resource_info.num_storage_buffers == 0, "num_storage_buffers is %d, should be 0", shader_gfx_metadata->resource_info.num_storage_buffers);
+    SDLTest_AssertCheck(shader_gfx_metadata->resource_info.num_uniform_buffers == 1, "num_uniform_buffers is %d, should be 1", shader_gfx_metadata->resource_info.num_uniform_buffers);
     SDLTest_AssertCheck(shader_gfx_metadata->num_inputs == 1, "num_inputs is %d, should be 1", shader_gfx_metadata->num_inputs);
     SDLTest_AssertCheck(shader_gfx_metadata->num_outputs == 1, "num_outputs is %d, should be 1", shader_gfx_metadata->num_outputs);
 


### PR DESCRIPTION
Alternate implementation of #175 

I think this is straightforwardly better.