### PR TITLE
Rename property keys to use SDL_shadercross namespace

### DIFF
--- a/include/SDL3_shadercross/SDL_shadercross.h
+++ b/include/SDL3_shadercross/SDL_shadercross.h
@@ -111,8 +111,8 @@ typedef struct SDL_ShaderCross_SPIRV_Info
 #define SDL_SHADERCROSS_PROP_SHADER_DEBUG_NAME_STRING "SDL_shadercross.spirv.debug.name"
 #define SDL_SHADERCROSS_PROP_SHADER_CULL_UNUSED_BINDINGS_BOOL "SDL_shadercross.spirv.cull_unused_bindings"
 
-#define SDL_SHADERCROSS_PROP_SPIRV_PSSL_COMPATIBILITY "SDL.shadercross.spirv.pssl.compatibility"
-#define SDL_SHADERCROSS_PROP_SPIRV_MSL_VERSION "SDL.shadercross.spirv.msl.version"
+#define SDL_SHADERCROSS_PROP_SPIRV_PSSL_COMPATIBILITY "SDL_shadercross.spirv.pssl.compatibility"
+#define SDL_SHADERCROSS_PROP_SPIRV_MSL_VERSION "SDL_shadercross.spirv.msl.version"
 
 typedef struct SDL_ShaderCross_HLSL_Define
 {


### PR DESCRIPTION
From #173 

> The property key names should be renamed to be in the SDL_shadercross namespace. For example SDL.shadercross.spirv.pssl.compatibility should be renamed SDL_shadercross.spirv.pssl.compatibility

