### PR TITLE
Fix property type suffixes

### DIFF
--- a/include/SDL3_shadercross/SDL_shadercross.h
+++ b/include/SDL3_shadercross/SDL_shadercross.h
@@ -107,12 +107,12 @@ typedef struct SDL_ShaderCross_SPIRV_Info
     SDL_PropertiesID props;                    /**< A properties ID for extensions. Should be 0 if no extensions are needed. */
 } SDL_ShaderCross_SPIRV_Info;
 
-#define SDL_SHADERCROSS_PROP_SHADER_DEBUG_ENABLE_BOOL "SDL_shadercross.spirv.debug.enable"
+#define SDL_SHADERCROSS_PROP_SHADER_DEBUG_ENABLE_BOOLEAN "SDL_shadercross.spirv.debug.enable"
 #define SDL_SHADERCROSS_PROP_SHADER_DEBUG_NAME_STRING "SDL_shadercross.spirv.debug.name"
-#define SDL_SHADERCROSS_PROP_SHADER_CULL_UNUSED_BINDINGS_BOOL "SDL_shadercross.spirv.cull_unused_bindings"
+#define SDL_SHADERCROSS_PROP_SHADER_CULL_UNUSED_BINDINGS_BOOLEAN "SDL_shadercross.spirv.cull_unused_bindings"
 
-#define SDL_SHADERCROSS_PROP_SPIRV_PSSL_COMPATIBILITY "SDL_shadercross.spirv.pssl.compatibility"
-#define SDL_SHADERCROSS_PROP_SPIRV_MSL_VERSION "SDL_shadercross.spirv.msl.version"
+#define SDL_SHADERCROSS_PROP_SPIRV_PSSL_COMPATIBILITY_BOOLEAN "SDL_shadercross.spirv.pssl.compatibility"
+#define SDL_SHADERCROSS_PROP_SPIRV_MSL_VERSION_STRING "SDL_shadercross.spirv.msl.version"
 
 typedef struct SDL_ShaderCross_HLSL_Define
 {
@@ -160,7 +160,7 @@ extern SDL_DECLSPEC SDL_GPUShaderFormat SDLCALL SDL_ShaderCross_GetSPIRVShaderFo
  *
  * These are the optional properties that can be used:
  *
- * - `SDL_SHADERCROSS_PROP_SPIRV_MSL_VERSION`: specifies the MSL version that should be emitted. Defaults to 1.2.0.
+ * - `SDL_SHADERCROSS_PROP_SPIRV_MSL_VERSION_STRING`: specifies the MSL version that should be emitted. Defaults to 1.2.0.
  *
  * \param info a struct describing the shader to transpile.
  * \returns an SDL_malloc'd string containing MSL code.
@@ -175,7 +175,7 @@ extern SDL_DECLSPEC void * SDLCALL SDL_ShaderCross_TranspileMSLFromSPIRV(
  *
  * These are the optional properties that can be used:
  *
- * - `SDL_SHADERCROSS_PROP_SPIRV_PSSL_COMPATIBILITY`: generates PSSL-compatible shader.
+ * - `SDL_SHADERCROSS_PROP_SPIRV_PSSL_COMPATIBILITY_BOOLEAN`: generates PSSL-compatible shader.
  *
  * \param info a struct describing the shader to transpile.
  * \returns an SDL_malloc'd string containing HLSL code.
@@ -289,9 +289,9 @@ extern SDL_DECLSPEC SDL_GPUShaderFormat SDLCALL SDL_ShaderCross_GetHLSLShaderFor
  *
  * These are the optional properties that can be used:
  *
- * - `SDL_SHADERCROSS_PROP_SHADER_DEBUG_ENABLE_BOOL`: allows debug info to be emitted when relevant. Should only be used with debugging tools like Renderdoc.
- * - `SDL_SHADERCROSS_PROP_SHADER_DEBUG_ENABLE_BOOL`: a UTF-8 name to be used with the shader. Relevant for use with debugging tools like Renderdoc.
- * - `SDL_SHADERCROSS_PROP_SHADER_CULL_UNUSED_BINDINGS_BOOL`: When true, indicates that the compiler should not cull unused shader resources. This behavior is disabled by default.
+ * - `SDL_SHADERCROSS_PROP_SHADER_DEBUG_ENABLE_BOOLEAN`: allows debug info to be emitted when relevant. Should only be used with debugging tools like Renderdoc.
+ * - `SDL_SHADERCROSS_PROP_SHADER_DEBUG_ENABLE_BOOLEAN`: a UTF-8 name to be used with the shader. Relevant for use with debugging tools like Renderdoc.
+ * - `SDL_SHADERCROSS_PROP_SHADER_CULL_UNUSED_BINDINGS_BOOLEAN`: When true, indicates that the compiler should not cull unused shader resources. This behavior is disabled by default.
  *
  * \param info a struct describing the shader to transpile.
  * \param size filled in with the bytecode buffer size.
@@ -310,9 +310,9 @@ extern SDL_DECLSPEC void * SDLCALL SDL_ShaderCross_CompileDXBCFromHLSL(
  *
  * These are the optional properties that can be used:
  *
- * - `SDL_SHADERCROSS_PROP_SHADER_DEBUG_ENABLE_BOOL`: allows debug info to be emitted when relevant. Should only be used with debugging tools like Renderdoc.
+ * - `SDL_SHADERCROSS_PROP_SHADER_DEBUG_ENABLE_BOOLEAN`: allows debug info to be emitted when relevant. Should only be used with debugging tools like Renderdoc.
  * - `SDL_SHADERCROSS_PROP_SHADER_DEBUG_NAME_STRING`: a UTF-8 name to be used with the shader. Relevant for use with debugging tools like Renderdoc.
- * - `SDL_SHADERCROSS_PROP_SHADER_CULL_UNUSED_BINDINGS_BOOL`: when true, indicates that the compiler should not cull unused shader resources. This behavior is disabled by default.
+ * - `SDL_SHADERCROSS_PROP_SHADER_CULL_UNUSED_BINDINGS_BOOLEAN`: when true, indicates that the compiler should not cull unused shader resources. This behavior is disabled by default.
  *
  * \param info a struct describing the shader to transpile.
  * \param size filled in with the bytecode buffer size.
@@ -331,9 +331,9 @@ extern SDL_DECLSPEC void * SDLCALL SDL_ShaderCross_CompileDXILFromHLSL(
  *
  * These are the optional properties that can be used:
  *
- * - `SDL_SHADERCROSS_PROP_SHADER_DEBUG_ENABLE_BOOL`: allows debug info to be emitted when relevant. Should only be used with debugging tools like Renderdoc.
+ * - `SDL_SHADERCROSS_PROP_SHADER_DEBUG_ENABLE_BOOLEAN`: allows debug info to be emitted when relevant. Should only be used with debugging tools like Renderdoc.
  * - `SDL_SHADERCROSS_PROP_SHADER_DEBUG_NAME_STRING`: a UTF-8 name to be used with the shader. Relevant for use with debugging tools like Renderdoc.
- * - `SDL_SHADERCROSS_PROP_SHADER_CULL_UNUSED_BINDINGS_BOOL`: when true, indicates that the compiler should not cull unused shader resources. This behavior is disabled by default.
+ * - `SDL_SHADERCROSS_PROP_SHADER_CULL_UNUSED_BINDINGS_BOOLEAN`: when true, indicates that the compiler should not cull unused shader resources. This behavior is disabled by default.
  *
  * \param info a struct describing the shader to transpile.
  * \param size filled in with the bytecode buffer size.

--- a/src/SDL_shadercross.c
+++ b/src/SDL_shadercross.c
@@ -447,7 +447,7 @@ static void *SDL_ShaderCross_INTERNAL_CompileUsingDXC(
         args[argCount++] = (LPCWSTR)L"-spirv";
         args[argCount++] = (LPCWSTR)L"-fspv-flatten-resource-arrays";
 
-        if (!SDL_GetBooleanProperty(info->props, SDL_SHADERCROSS_PROP_SHADER_CULL_UNUSED_BINDINGS_BOOL, false))
+        if (!SDL_GetBooleanProperty(info->props, SDL_SHADERCROSS_PROP_SHADER_CULL_UNUSED_BINDINGS_BOOLEAN, false))
         {
             args[argCount++] = (LPCWSTR)L"-fspv-preserve-bindings";
         }
@@ -455,7 +455,7 @@ static void *SDL_ShaderCross_INTERNAL_CompileUsingDXC(
         args[argCount++] = (LPCWSTR)L"-fspv-preserve-interface";
     }
 
-    if (SDL_GetBooleanProperty(info->props, SDL_SHADERCROSS_PROP_SHADER_DEBUG_ENABLE_BOOL, false)) {
+    if (SDL_GetBooleanProperty(info->props, SDL_SHADERCROSS_PROP_SHADER_DEBUG_ENABLE_BOOLEAN, false)) {
         if (spirv) {
             // https://github.com/microsoft/DirectXShaderCompiler/blob/main/docs/SPIR-V.rst#debugging
             args[argCount++] = (LPCWSTR)L"-fspv-debug=vulkan-with-source";
@@ -799,7 +799,7 @@ void *SDL_ShaderCross_INTERNAL_CompileDXBCFromHLSL(
         transpiledSource != NULL ? transpiledSource : info->source,
         info->entrypoint,
         shaderProfile,
-        SDL_GetBooleanProperty(info->props, SDL_SHADERCROSS_PROP_SHADER_DEBUG_ENABLE_BOOL, false));
+        SDL_GetBooleanProperty(info->props, SDL_SHADERCROSS_PROP_SHADER_DEBUG_ENABLE_BOOLEAN, false));
 
     if (blob == NULL) {
         SDL_free(transpiledSource);
@@ -915,7 +915,7 @@ static SPIRVTranspileContext *SDL_ShaderCross_INTERNAL_TranspileFromSPIRV(
         spvc_compiler_options_set_uint(options, SPVC_COMPILER_OPTION_HLSL_SHADER_MODEL, shadermodel);
         spvc_compiler_options_set_uint(options, SPVC_COMPILER_OPTION_HLSL_NONWRITABLE_UAV_TEXTURE_AS_SRV, 1);
         spvc_compiler_options_set_uint(options, SPVC_COMPILER_OPTION_HLSL_FLATTEN_MATRIX_VERTEX_INPUT_SEMANTICS, 1);
-        spvc_compiler_options_set_bool(options, SPVC_COMPILER_OPTION_HLSL_USE_ENTRY_POINT_NAME, !SDL_GetBooleanProperty(props, SDL_SHADERCROSS_PROP_SPIRV_PSSL_COMPATIBILITY, false));
+        spvc_compiler_options_set_bool(options, SPVC_COMPILER_OPTION_HLSL_USE_ENTRY_POINT_NAME, !SDL_GetBooleanProperty(props, SDL_SHADERCROSS_PROP_SPIRV_PSSL_COMPATIBILITY_BOOLEAN, false));
         spvc_compiler_options_set_bool(options, SPVC_COMPILER_OPTION_HLSL_POINT_SIZE_COMPAT, true);
     }
 
@@ -933,7 +933,7 @@ static SPIRVTranspileContext *SDL_ShaderCross_INTERNAL_TranspileFromSPIRV(
     }
 
     if (backend == SPVC_BACKEND_MSL) {
-        const char *_mslVersion = SDL_GetStringProperty(props, SDL_SHADERCROSS_PROP_SPIRV_MSL_VERSION, "1.2.0");
+        const char *_mslVersion = SDL_GetStringProperty(props, SDL_SHADERCROSS_PROP_SPIRV_MSL_VERSION_STRING, "1.2.0");
         int mslVersion = parse_version_number(_mslVersion);
         if (mslVersion == - 1) {
             SDL_SetError("failed to parse MSL version string \"%s\"", _mslVersion);
@@ -2335,7 +2335,7 @@ void *SDL_ShaderCross_TranspileHLSLFromSPIRV(
 
     SPIRVTranspileContext *context = SDL_ShaderCross_INTERNAL_TranspileFromSPIRV(
         SPVC_BACKEND_HLSL,
-        SDL_GetBooleanProperty(info->props, SDL_SHADERCROSS_PROP_SPIRV_PSSL_COMPATIBILITY, false) ? 50 : 60,
+        SDL_GetBooleanProperty(info->props, SDL_SHADERCROSS_PROP_SPIRV_PSSL_COMPATIBILITY_BOOLEAN, false) ? 50 : 60,
         info->shader_stage,
         info->bytecode,
         info->bytecode_size,

--- a/src/cli.c
+++ b/src/cli.c
@@ -494,17 +494,17 @@ int main(int argc, char *argv[])
         spirvInfo.shader_stage = shaderStage;
         spirvInfo.props = SDL_CreateProperties();
         if (enableDebug) {
-            SDL_SetBooleanProperty(spirvInfo.props, SDL_SHADERCROSS_PROP_SHADER_DEBUG_ENABLE_BOOL, true);
+            SDL_SetBooleanProperty(spirvInfo.props, SDL_SHADERCROSS_PROP_SHADER_DEBUG_ENABLE_BOOLEAN, true);
             SDL_SetBooleanProperty(spirvInfo.props, SDL_SHADERCROSS_PROP_SHADER_DEBUG_NAME_STRING, filename);
         }
         if (cullUnusedBindings) {
-            SDL_SetBooleanProperty(spirvInfo.props, SDL_SHADERCROSS_PROP_SHADER_CULL_UNUSED_BINDINGS_BOOL, true);
+            SDL_SetBooleanProperty(spirvInfo.props, SDL_SHADERCROSS_PROP_SHADER_CULL_UNUSED_BINDINGS_BOOLEAN, true);
         }
         if (mslVersion) {
-            SDL_SetStringProperty(spirvInfo.props, SDL_SHADERCROSS_PROP_SPIRV_MSL_VERSION, mslVersion);
+            SDL_SetStringProperty(spirvInfo.props, SDL_SHADERCROSS_PROP_SPIRV_MSL_VERSION_STRING, mslVersion);
         }
         if (psslCompat) {
-            SDL_SetBooleanProperty(spirvInfo.props, SDL_SHADERCROSS_PROP_SPIRV_PSSL_COMPATIBILITY, true);
+            SDL_SetBooleanProperty(spirvInfo.props, SDL_SHADERCROSS_PROP_SPIRV_PSSL_COMPATIBILITY_BOOLEAN, true);
         }
 
         switch (destinationFormat) {
@@ -615,12 +615,12 @@ int main(int argc, char *argv[])
         hlslInfo.props = SDL_CreateProperties();
 
         if (enableDebug) {
-            SDL_SetBooleanProperty(hlslInfo.props, SDL_SHADERCROSS_PROP_SHADER_DEBUG_ENABLE_BOOL, true);
+            SDL_SetBooleanProperty(hlslInfo.props, SDL_SHADERCROSS_PROP_SHADER_DEBUG_ENABLE_BOOLEAN, true);
             SDL_SetStringProperty(hlslInfo.props, SDL_SHADERCROSS_PROP_SHADER_DEBUG_NAME_STRING, filename);
         }
 
         if (cullUnusedBindings) {
-            SDL_SetBooleanProperty(hlslInfo.props, SDL_SHADERCROSS_PROP_SHADER_CULL_UNUSED_BINDINGS_BOOL, true);
+            SDL_SetBooleanProperty(hlslInfo.props, SDL_SHADERCROSS_PROP_SHADER_CULL_UNUSED_BINDINGS_BOOLEAN, true);
         }
 
         switch (destinationFormat) {
@@ -669,14 +669,14 @@ int main(int argc, char *argv[])
                     spirvInfo.props = SDL_CreateProperties();
 
                     if (enableDebug) {
-                        SDL_SetBooleanProperty(spirvInfo.props, SDL_SHADERCROSS_PROP_SHADER_DEBUG_ENABLE_BOOL, true);
+                        SDL_SetBooleanProperty(spirvInfo.props, SDL_SHADERCROSS_PROP_SHADER_DEBUG_ENABLE_BOOLEAN, true);
                         SDL_SetStringProperty(spirvInfo.props, SDL_SHADERCROSS_PROP_SHADER_DEBUG_NAME_STRING, filename);
                     }
                     if (cullUnusedBindings) {
-                        SDL_SetBooleanProperty(spirvInfo.props, SDL_SHADERCROSS_PROP_SHADER_DEBUG_ENABLE_BOOL, true);
+                        SDL_SetBooleanProperty(spirvInfo.props, SDL_SHADERCROSS_PROP_SHADER_DEBUG_ENABLE_BOOLEAN, true);
                     }
                     if (mslVersion) {
-                        SDL_SetStringProperty(spirvInfo.props, SDL_SHADERCROSS_PROP_SPIRV_MSL_VERSION, mslVersion);
+                        SDL_SetStringProperty(spirvInfo.props, SDL_SHADERCROSS_PROP_SPIRV_MSL_VERSION_STRING, mslVersion);
                     }
 
                     char *buffer = SDL_ShaderCross_TranspileMSLFromSPIRV(
@@ -727,14 +727,14 @@ int main(int argc, char *argv[])
                 spirvInfo.props = SDL_CreateProperties();
 
                 if (enableDebug) {
-                    SDL_SetBooleanProperty(spirvInfo.props, SDL_SHADERCROSS_PROP_SHADER_DEBUG_ENABLE_BOOL, true);
+                    SDL_SetBooleanProperty(spirvInfo.props, SDL_SHADERCROSS_PROP_SHADER_DEBUG_ENABLE_BOOLEAN, true);
                     SDL_SetStringProperty(spirvInfo.props, SDL_SHADERCROSS_PROP_SHADER_DEBUG_NAME_STRING, filename);
                 }
                 if (cullUnusedBindings) {
-                    SDL_SetBooleanProperty(spirvInfo.props, SDL_SHADERCROSS_PROP_SHADER_CULL_UNUSED_BINDINGS_BOOL, true);
+                    SDL_SetBooleanProperty(spirvInfo.props, SDL_SHADERCROSS_PROP_SHADER_CULL_UNUSED_BINDINGS_BOOLEAN, true);
                 }
                 if (psslCompat) {
-                    SDL_SetBooleanProperty(spirvInfo.props, SDL_SHADERCROSS_PROP_SPIRV_PSSL_COMPATIBILITY, true);
+                    SDL_SetBooleanProperty(spirvInfo.props, SDL_SHADERCROSS_PROP_SPIRV_PSSL_COMPATIBILITY_BOOLEAN, true);
                 }
 
                 char *buffer = SDL_ShaderCross_TranspileHLSLFromSPIRV(

--- a/test/main.c
+++ b/test/main.c
@@ -68,7 +68,7 @@ static int SDLCALL shadercross_CompileHLSL_to_XXX(void *args)
         hlsl_info.entrypoint = "main";
         hlsl_info.shader_stage = SDL_SHADERCROSS_SHADERSTAGE_VERTEX;
         hlsl_info.props = SDL_CreateProperties();
-        SDL_SetBooleanProperty(hlsl_info.props, SDL_SHADERCROSS_PROP_SHADER_DEBUG_ENABLE_BOOL, true);
+        SDL_SetBooleanProperty(hlsl_info.props, SDL_SHADERCROSS_PROP_SHADER_DEBUG_ENABLE_BOOLEAN, true);
         SDL_SetStringProperty(hlsl_info.props, SDL_SHADERCROSS_PROP_SHADER_DEBUG_NAME_STRING, "Simple shader");
         shader_size = 0;
         shader = cases[i].compile_XXXFromHLSL(&hlsl_info, &shader_size);
@@ -166,7 +166,7 @@ static int SDLCALL shadercross_CompileSPIRV_to_XXX(void *args)
         spirv_info.entrypoint = "main";
         spirv_info.shader_stage = SDL_SHADERCROSS_SHADERSTAGE_VERTEX;
         spirv_info.props = SDL_CreateProperties();
-        SDL_SetBooleanProperty(spirv_info.props, SDL_SHADERCROSS_PROP_SHADER_DEBUG_ENABLE_BOOL, true);
+        SDL_SetBooleanProperty(spirv_info.props, SDL_SHADERCROSS_PROP_SHADER_DEBUG_ENABLE_BOOLEAN, true);
         SDL_SetStringProperty(spirv_info.props, SDL_SHADERCROSS_PROP_SHADER_DEBUG_NAME_STRING, "Simple shader");
         shader_size = 0;
         shader = cases[i].compile_XXXFromSPIRV(&spirv_info, &shader_size);


### PR DESCRIPTION
This changes the BOOL suffix of properties to BOOLEAN to match SDL and the other satellite libs, and adds some missing suffixes