### PR TITLE
Get SDL_GPUVertexElementFormat from IOVarMetadata

### DIFF
--- a/include/SDL3_shadercross/SDL_shadercross.h
+++ b/include/SDL3_shadercross/SDL_shadercross.h
@@ -345,6 +345,12 @@ extern SDL_DECLSPEC void * SDLCALL SDL_ShaderCross_CompileSPIRVFromHLSL(
     const SDL_ShaderCross_HLSL_Info *info,
     size_t *size);
 
+/**
+ * Returns the SDL_GPUVertexElementFormat from a variable's SDL_ShaderCross_IOVarMetadata
+*/
+extern SDL_DECLSPEC SDL_GPUVertexElementFormat SDLCALL SDL_ShaderCross_GPUVertexElementFormatFromIOVarMetadata(
+    const SDL_ShaderCross_IOVarMetadata *meta);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/SDL_shadercross.c
+++ b/src/SDL_shadercross.c
@@ -2650,3 +2650,28 @@ SDL_GPUShaderFormat SDL_ShaderCross_GetHLSLShaderFormats(void)
 
     return supportedFormats;
 }
+
+SDL_GPUVertexElementFormat SDL_ShaderCross_GPUVertexElementFormatFromIOVarMetadata(
+    const SDL_ShaderCross_IOVarMetadata *meta)
+{
+    if (meta == NULL) {
+        SDL_InvalidParamError("metadata");
+        return SDL_GPU_VERTEXELEMENTFORMAT_INVALID;
+    }
+
+    switch (meta->vector_type) {
+    case SDL_SHADERCROSS_IOVAR_TYPE_INT8: return SDL_GPU_VERTEXELEMENTFORMAT_BYTE2 + meta->vector_size/2 - 1;
+    case SDL_SHADERCROSS_IOVAR_TYPE_UINT8: return SDL_GPU_VERTEXELEMENTFORMAT_UBYTE2 + meta->vector_size/2 - 1;
+
+    case SDL_SHADERCROSS_IOVAR_TYPE_INT16: return SDL_GPU_VERTEXELEMENTFORMAT_SHORT2 + meta->vector_size/2 - 1;
+    case SDL_SHADERCROSS_IOVAR_TYPE_UINT16: return SDL_GPU_VERTEXELEMENTFORMAT_USHORT2 + meta->vector_size/2 - 1;
+    case SDL_SHADERCROSS_IOVAR_TYPE_FLOAT16: return SDL_GPU_VERTEXELEMENTFORMAT_HALF2 + meta->vector_size/2 - 1;
+
+    case SDL_SHADERCROSS_IOVAR_TYPE_INT32: return SDL_GPU_VERTEXELEMENTFORMAT_INT + meta->vector_size - 1;
+    case SDL_SHADERCROSS_IOVAR_TYPE_UINT32: return SDL_GPU_VERTEXELEMENTFORMAT_UINT + meta->vector_size - 1;
+    case SDL_SHADERCROSS_IOVAR_TYPE_FLOAT32: return SDL_GPU_VERTEXELEMENTFORMAT_FLOAT + meta->vector_size - 1;
+
+    /* SDL_gpu api does not include 64-bit types in SDL_GPUVertexElementFormat */
+    default: return SDL_GPU_VERTEXELEMENTFORMAT_INVALID;
+    }
+}


### PR DESCRIPTION
Added: SDL_ShaderCross_GPUVertexElementFormatFromIOVarMetadata
Maybe the name could be shorter? I wanted to keep similar to the name of the other functions

Very simple function but very useful when using SDL_shadercross with SDL_gpu api. Specifically when creating a pipeline with SDL_gpu from shaders compiled with SDL_shadercross.

Also, not sure where in SDL_shadercross.c it should go, so I just put it in the end of the file, same for SDL_shadercross.h