### PR TITLE
CompileDXILFromSPIRV: Skipping the HLSL->SPIR-V->HLSL roundtrip.

### DIFF
--- a/src/SDL_shadercross.c
+++ b/src/SDL_shadercross.c
@@ -2429,9 +2429,10 @@ void *SDL_ShaderCross_CompileDXILFromSPIRV(
     hlslInfo.shader_stage = info->shader_stage;
     hlslInfo.props = info->props;
 
-    void *result = SDL_ShaderCross_CompileDXILFromHLSL(
-        &hlslInfo,
-        size);
+    void *result = SDL_ShaderCross_INTERNAL_CompileUsingDXC(
+      &hlslInfo,
+      false,
+      size);
 
     SDL_ShaderCross_INTERNAL_DestroyTranspileContext(context);
     return result;


### PR DESCRIPTION
As mentioned in #169, the round-trip through SPIR-V is unnecessary in this case, since the code comes from decompiling SPIR-V. 

What we get by skipping the roundtrip is a partial workaround for #169 (for this one use case), plus this function in general being faster with 2 compilation steps instead of 4.

The change consists of using `SDL_ShaderCross_INTERNAL_CompileUsingDXC` directly instead of going through the public HLSL->DXIL function.