### PR TITLE
Add ELF dlopen note for libvkd3d-utils (hlsl->dxbc)

### DIFF
--- a/src/SDL_shadercross.c
+++ b/src/SDL_shadercross.c
@@ -654,6 +654,15 @@ typedef void ID3DInclude;      /* hack, unused */
 #define D3DCOMPILER_DLL "libvkd3d-utils.so.1"
 #endif
 
+#ifdef SDL_ELF_NOTE_DLOPEN
+SDL_ELF_NOTE_DLOPEN(
+    "dxbc",
+    "Create DXBC shaders from HLSL",
+    SDL_ELF_NOTE_DLOPEN_PRIORITY_SUGGESTED,
+    D3DCOMPILER_DLL
+)
+#endif
+
 /* __stdcall declaration, largely taken from vkd3d_windows.h */
 #ifndef _WIN32
 #ifdef __stdcall


### PR DESCRIPTION
```
$ dlopen-notes.py libSDL3_shadercross.so.0
# libSDL3_shadercross.so.0
[
  {
    "feature": "dxbc",
    "description": "Create DXBC shaders from HLSL",
    "priority": "suggested",
    "soname": [
      "libvkd3d-utils.so.1"
    ]
  }
]
```